### PR TITLE
refactor: replace hardcoded value with release name in NOTES.txt

### DIFF
--- a/charts/incubator/hyperswitch-stack/templates/NOTES.txt
+++ b/charts/incubator/hyperswitch-stack/templates/NOTES.txt
@@ -5,7 +5,7 @@ if [ -z "$ADDRESS_CREATED" ]
 then
   kubectl port-forward deployment/hyperswitch-server-v1o52o1v2 8080:8080 -n {{ .Release.Namespace }} & \
   kubectl port-forward deployment/hyperswitch-control-center-0f746cb72517 9000:9000 -n {{ .Release.Namespace }} & \
-  kubectl port-forward service/hypers-v1-hyperswitchsdk 9090:9090 -n {{ .Release.Namespace }} & \
+  kubectl port-forward service/{{ .Release.Name }}-hyperswitchsdk 9090:9090 -n {{ .Release.Namespace }} & \
   echo "======================================================"
   echo "** App server running on: http://localhost:8080      **"
   echo "** Control center running on: http://localhost:9000  **"


### PR DESCRIPTION
#78 
Fixed the code to take the service name from the Release Name instead of hardcoding it.

Output:
```
NOTES:
1. Get the application URL by running these commands:

export ADDRESS_CREATED=$(kubectl get ingress -n hyperswitch -o jsonpath="{.items[0].status.addresses[0].address}")
if [ -z "$ADDRESS_CREATED" ]
then
  kubectl port-forward deployment/hyperswitch-server-v1o52o1v2 8080:8080 -n hyperswitch & \
  kubectl port-forward deployment/hyperswitch-control-center-0f746cb72517 9000:9000 -n hyperswitch & \
  kubectl port-forward service/hyperswitch-v1-hyperswitchsdk 9090:9090 -n hyperswitch & \
  echo "======================================================"
  echo "** App server running on: http://localhost:8080      **"
  echo "** Control center running on: http://localhost:9000  **"
  echo "** Hyperswitch Web running on: http://localhost:9090 **"
  echo "======================================================"
  echo "\nRun this command to close exposed ports kill\n"
  echo "kill \$( lsof -i:8080 -t ) && kill \$( lsof -i:9090 -t ) && kill \$( lsof -i:9000 -t )"
  echo "======================================================"
else
  kubectl get ingress -n hyperswitch
fi
```