### PR TITLE
chore: package charts not included as dependencies of 'hyperswitch-stack'

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -35,3 +35,20 @@ tasks:
     cmds:
       - >
         helm repo index repo 
+
+  package-incubator-chart:
+    desc: Package either of the two incubator charts not included in the 'hyperswitch-stack' chart (istio, keymanager)
+    requires:
+      vars:
+        - name: CHART
+          enum: [istio, keymanager]
+    #language=sh
+    cmds:
+      - >
+        CHART="hyperswitch-{{.CHART}}" &&
+        STACK=charts/incubator/$CHART &&
+        version=$(grep '^version:' $STACK/Chart.yaml | awk '{print $2}') &&
+        helm package $STACK --dependency-update &&
+        helm repo index $STACK --url https://juspay.github.io/hyperswitch-helm/$STACK &&
+        mv $CHART-$version.tgz $STACK
+


### PR DESCRIPTION
#### Summary
This commit adds a new task one can use to package the
'hyperswitch-istio' and 'hyperswitch-keymanager' charts in the event
that a change to one of them is required.

#### Testing

```
~/workplace/sft-multi-pay-hyperswitch-helm  ↱ fix_keymanager_helm_ext_pgsql_enabled ±  task package-incubator-chart CHART=keymanager
task: [package-incubator-chart] CHART="hyperswitch-keymanager" && STACK=charts/incubator/$CHART && version=$(grep '^version:' $STACK/Chart.yaml | awk '{print $2}') && helm package $STACK --dependency-update && helm repo index $STACK --url https://juspay.github.io/hyperswitch-helm/$STACK && mv $CHART-$version.tgz $STACK

Successfully packaged chart and saved it to: /Users/willem.barkhuizen/workplace/sft-multi-pay-hyperswitch-helm/hyperswitch-keymanager-0.1.0.tgz
~/workplace/sft-multi-pay-hyperswitch-helm  ↱ fix_keymanager_helm_ext_pgsql_enabled ±  git status
On branch fix_keymanager_helm_ext_pgsql_enabled
Your branch is ahead of 'upstream/main' by 1 commit.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   Taskfile.yaml
	modified:   charts/incubator/hyperswitch-keymanager/hyperswitch-keymanager-0.1.0.tgz
	modified:   charts/incubator/hyperswitch-keymanager/index.yaml

no changes added to commit (use "git add" and/or "git commit -a")
```

---

Signed-Off-By: Willem Barkhuizen (<willem.barkhuizen@sanlam.co.za>)
