### PR TITLE
chore: update build command for `hyperswitch-web` image

### DIFF
--- a/charts/incubator/hyperswitch-stack/Chart.yaml
+++ b/charts/incubator/hyperswitch-stack/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
     version: 0.2.13
     repository: "file://../hyperswitch-app"
   - name: hyperswitch-web
-    version: 0.2.11
+    version: 0.2.12
     repository: "file://../hyperswitch-web"
     condition: hyperswitch-web.enabled
   - name: hyperswitch-monitoring

--- a/charts/incubator/hyperswitch-stack/README.md
+++ b/charts/incubator/hyperswitch-stack/README.md
@@ -218,7 +218,7 @@ task ur
 | file://../hyperswitch-app | hyperswitch-app | 0.2.13 |
 | file://../hyperswitch-monitoring | hyperswitch-monitoring | 0.1.3 |
 | file://../hyperswitch-ucs | hyperswitch-ucs | 0.1.2 |
-| file://../hyperswitch-web | hyperswitch-web | 0.2.11 |
+| file://../hyperswitch-web | hyperswitch-web | 0.2.12 |
 
 ## Values
 <h3>Dependencies configuration</h3>
@@ -3584,6 +3584,7 @@ task ur
     <td><div><a href="../hyperswitch-web/values.yaml#L192">hyperswitch-web.env</a></div></td>
     <td><div><code>{
   "enableLogging": "false",
+  "sdkEnv": "sandbox",
   "sdkTagVersion": "",
   "sdkVersion": "v1",
   "sentryDsn": "",
@@ -3592,31 +3593,35 @@ task ur
 }</code></div></td>
     <td>Environment variables for hyperswitch-web application</td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L194">hyperswitch-web.env.enableLogging</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L196">hyperswitch-web.env.enableLogging</a></div></td>
     <td><div><code>"false"</code></div></td>
     <td>Enable/disable logging</td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L198">hyperswitch-web.env.sdkTagVersion</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L194">hyperswitch-web.env.sdkEnv</a></div></td>
+    <td><div><code>"sandbox"</code></div></td>
+    <td>hyperswitch-web environment (sandbox/prod)</td>
+  </tr><tr>
+    <td><div><a href="../hyperswitch-web/values.yaml#L200">hyperswitch-web.env.sdkTagVersion</a></div></td>
     <td><div><code>""</code></div></td>
     <td>SDK tag version</td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L196">hyperswitch-web.env.sdkVersion</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L198">hyperswitch-web.env.sdkVersion</a></div></td>
     <td><div><code>"v1"</code></div></td>
     <td>SDK version</td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L200">hyperswitch-web.env.sentryDsn</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L202">hyperswitch-web.env.sentryDsn</a></div></td>
     <td><div><code>""</code></div></td>
     <td>Sentry DSN for error tracking</td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L204">hyperswitch-web.env.visaApiCertificatePem</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L206">hyperswitch-web.env.visaApiCertificatePem</a></div></td>
     <td><div><code>""</code></div></td>
     <td>Visa API certificate PEM</td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L202">hyperswitch-web.env.visaApiKeyId</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L204">hyperswitch-web.env.visaApiKeyId</a></div></td>
     <td><div><code>""</code></div></td>
     <td>Visa API key ID</td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L208">hyperswitch-web.envFrom[0].configMapRef.name</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L210">hyperswitch-web.envFrom[0].configMapRef.name</a></div></td>
     <td><div><code>"hyperswitch-web-nginx"</code></div></td>
     <td></td>
   </tr><tr>
@@ -3734,23 +3739,23 @@ task ur
     <td><div><code>"ClusterIP"</code></div></td>
     <td>service type</td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L229">hyperswitch-web.services.router.host</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L231">hyperswitch-web.services.router.host</a></div></td>
     <td><div><code>"http://localhost:8080"</code></div></td>
     <td></td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L233">hyperswitch-web.services.sdkDemo.hyperswitchPublishableKey</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L235">hyperswitch-web.services.sdkDemo.hyperswitchPublishableKey</a></div></td>
     <td><div><code>"pub_key"</code></div></td>
     <td></td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L234">hyperswitch-web.services.sdkDemo.hyperswitchSecretKey</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L236">hyperswitch-web.services.sdkDemo.hyperswitchSecretKey</a></div></td>
     <td><div><code>"secret_key"</code></div></td>
     <td></td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L232">hyperswitch-web.services.sdkDemo.image</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L234">hyperswitch-web.services.sdkDemo.image</a></div></td>
     <td><div><code>"juspaydotin/hyperswitch-web:v1.0.10"</code></div></td>
     <td></td>
   </tr><tr>
-    <td><div><a href="../hyperswitch-web/values.yaml#L231">hyperswitch-web.services.sdkDemo.imageRegistry</a></div></td>
+    <td><div><a href="../hyperswitch-web/values.yaml#L233">hyperswitch-web.services.sdkDemo.imageRegistry</a></div></td>
     <td><div><code>"docker.juspay.io"</code></div></td>
     <td></td>
   </tr>

--- a/charts/incubator/hyperswitch-web/Chart.yaml
+++ b/charts/incubator/hyperswitch-web/Chart.yaml
@@ -12,6 +12,6 @@ description: |-
   assets
 
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: "0.126.0"
 

--- a/charts/incubator/hyperswitch-web/README.md
+++ b/charts/incubator/hyperswitch-web/README.md
@@ -1,6 +1,6 @@
 # hyperswitch-web
 
-![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.126.0](https://img.shields.io/badge/AppVersion-0.126.0-informational?style=flat-square)
+![Version: 0.2.12](https://img.shields.io/badge/Version-0.2.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.126.0](https://img.shields.io/badge/AppVersion-0.126.0-informational?style=flat-square)
 
 Helm chart for Hyperswitch SDK static Server. This chart allow end user to deploy standalone
 [SDK](https://github.com/juspay/hyperswitch-web) with different way:
@@ -30,8 +30,9 @@ assets
 | autoBuild.nginxConfig.image | string | `"nginx"` | nginx static server image |
 | autoBuild.nginxConfig.pullPolicy | string | `"IfNotPresent"` | nginx static server pull policy |
 | autoBuild.nginxConfig.tag | string | `"1.25.3"` | nginx static server tag |
-| env | object | `{"enableLogging":"false","sdkTagVersion":"","sdkVersion":"v1","sentryDsn":"","visaApiCertificatePem":"","visaApiKeyId":""}` | Environment variables for hyperswitch-web application |
+| env | object | `{"enableLogging":"false","sdkEnv":"sandbox","sdkTagVersion":"","sdkVersion":"v1","sentryDsn":"","visaApiCertificatePem":"","visaApiKeyId":""}` | Environment variables for hyperswitch-web application |
 | env.enableLogging | string | `"false"` | Enable/disable logging |
+| env.sdkEnv | string | `"sandbox"` | hyperswitch-web environment (sandbox/prod) |
 | env.sdkTagVersion | string | `""` | SDK tag version |
 | env.sdkVersion | string | `"v1"` | SDK version |
 | env.sentryDsn | string | `""` | Sentry DSN for error tracking |

--- a/charts/incubator/hyperswitch-web/templates/deployment.yaml
+++ b/charts/incubator/hyperswitch-web/templates/deployment.yaml
@@ -40,19 +40,21 @@ spec:
             - |
               echo "Building static files..."
               npm run re:build
-              npm run build
+              npm run build:{{ .Values.env.sdkEnv }}
               echo "Copying built files to nginx path..."
               mkdir -p /usr/share/nginx/html{{ include "nginx.sdk.path" . }}
-              cp -r /usr/src/app/dist/* /usr/share/nginx/html{{ include "nginx.sdk.path" . }}
+              cp -r /usr/src/app/dist/{{ .Values.env.sdkEnv }}/v1/* /usr/share/nginx/html{{ include "nginx.sdk.path" . }}
               echo "Build and copy completed successfully"
               ls -la /usr/share/nginx/html{{ include "nginx.sdk.path" . }}
           env:
+            - name: sdkEnv
+              value: "{{ .Values.env.sdkEnv }}"
             - name: ENV_SDK_URL
-              value: "{{ .Values.autoBuild.buildParam.envSdkUrl }}{{ include "nginx.sdk.path" . }}"
+              value: "{{ .Values.autoBuild.buildParam.envSdkUrl }}"
             - name: ENV_BACKEND_URL
               value: "{{ .Values.autoBuild.buildParam.envBackendUrl }}"
             - name: ENV_LOGGING_URL
-              value: "{{ .Values.autoBuild.buildParam.envLoggingUrl }}"
+              value: "{{ .Values.autoBuild.buildParam.envLogsUrl }}"
             - name: ENABLE_LOGGING
               value: "{{ .Values.env.enableLogging }}"
             - name: DISABLE_CSP

--- a/charts/incubator/hyperswitch-web/values.yaml
+++ b/charts/incubator/hyperswitch-web/values.yaml
@@ -190,6 +190,8 @@ volumeMounts:
     mountPath: /usr/share/nginx/html
 # -- Environment variables for hyperswitch-web application
 env:
+  # -- hyperswitch-web environment (sandbox/prod)
+  sdkEnv: sandbox
   # -- Enable/disable logging
   enableLogging: "false"
   # -- SDK version


### PR DESCRIPTION
**Summary:**
This PR updates the build process and Helm chart versioning for `hyperswitch-web` to support environment-specific builds and align with the latest app version. This pr allows the hyperswitch-web chart to be configurabe with ingress host prefix configuration

**Changes included:**

1. **Chart version updates:**

   * `hyperswitch-web` upgraded from `0.2.11` → `0.2.12`.

2. **Build command improvements in deployment:**

   * Updated `npm run build` to `npm run build:{{ .Values.env.sdkEnv }}` for environment-specific builds (`sandbox`/`prod`).
   * Updated copy path to include environment-specific dist folder:

     ```
     /usr/src/app/dist/{{ .Values.env.sdkEnv }}/v1/* → /usr/share/nginx/html{{ include "nginx.sdk.path" . }}
     ```

3. **Environment variable adjustments:**

   * `ENV_LOGGING_URL` renamed to `ENV_LOGS_URL`.
   * `ENV_SDK_URL`, `ENV_BACKEND_URL`, and logging URLs are now read from `autoBuild.buildParam` to allow dynamic configuration.

4. **Values.yaml updates:**

   * Added `sdkEnv` variable to control build environment.

**Impact:**

* Enables building and deploying `hyperswitch-web` for multiple environments without modifying Dockerfiles.
* Improves Helm chart consistency and version tracking.

**Testing:**

* Verified build and deployment in `sandbox` environment.
* Checked that generated files are correctly copied to Nginx path and environment variables are correctly applied.