### PR TITLE
chore: disabled ucs by default

### DIFF
--- a/charts/incubator/hyperswitch-monitoring/Chart.yaml
+++ b/charts/incubator/hyperswitch-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyperswitch-monitoring
 description: Monitoring stack for Hyperswitch including Prometheus, Loki, Promtail, and Grafana
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/incubator/hyperswitch-monitoring/README.md
+++ b/charts/incubator/hyperswitch-monitoring/README.md
@@ -593,7 +593,7 @@ The monitoring stack includes two custom dashboards:
     <td></td>
   </tr><tr>
     <td><div><a href="./values.yaml#L305">opentelemetry-collector.image.repository</a></div></td>
-    <td><div><code>"docker.io/otel/opentelemetry-collector-contrib"</code></div></td>
+    <td><div><code>"otel/opentelemetry-collector-contrib"</code></div></td>
     <td></td>
   </tr><tr>
     <td><div><a href="./values.yaml#L306">opentelemetry-collector.image.tag</a></div></td>

--- a/charts/incubator/hyperswitch-monitoring/README.md
+++ b/charts/incubator/hyperswitch-monitoring/README.md
@@ -2,7 +2,7 @@
 
 Monitoring stack for Hyperswitch including Prometheus, Loki, Promtail, and Grafana
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## Overview
 

--- a/charts/incubator/hyperswitch-monitoring/values.yaml
+++ b/charts/incubator/hyperswitch-monitoring/values.yaml
@@ -302,7 +302,7 @@ opentelemetry-collector:
             - prometheus
 
   image:
-    repository: docker.io/otel/opentelemetry-collector-contrib
+    repository: otel/opentelemetry-collector-contrib
     tag: 0.122.1
 
   nodeSelector: {}

--- a/charts/incubator/hyperswitch-stack/Chart.yaml
+++ b/charts/incubator/hyperswitch-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.14
+version: 0.2.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/incubator/hyperswitch-stack/Chart.yaml
+++ b/charts/incubator/hyperswitch-stack/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     repository: "file://../hyperswitch-web"
     condition: hyperswitch-web.enabled
   - name: hyperswitch-monitoring
-    version: 0.1.3
+    version: 0.1.4
     repository: "file://../hyperswitch-monitoring"
     condition: hyperswitch-monitoring.enabled
   - name: hyperswitch-ucs

--- a/charts/incubator/hyperswitch-stack/README.md
+++ b/charts/incubator/hyperswitch-stack/README.md
@@ -3306,7 +3306,7 @@ task ur
     <td></td>
   </tr><tr>
     <td><div><a href="../hyperswitch-monitoring/values.yaml#L305">hyperswitch-monitoring.opentelemetry-collector.image.repository</a></div></td>
-    <td><div><code>"docker.io/otel/opentelemetry-collector-contrib"</code></div></td>
+    <td><div><code>"otel/opentelemetry-collector-contrib"</code></div></td>
     <td></td>
   </tr><tr>
     <td><div><a href="../hyperswitch-monitoring/values.yaml#L306">hyperswitch-monitoring.opentelemetry-collector.image.tag</a></div></td>

--- a/charts/incubator/hyperswitch-stack/README.md
+++ b/charts/incubator/hyperswitch-stack/README.md
@@ -216,7 +216,7 @@ task ur
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../hyperswitch-app | hyperswitch-app | 0.2.13 |
-| file://../hyperswitch-monitoring | hyperswitch-monitoring | 0.1.3 |
+| file://../hyperswitch-monitoring | hyperswitch-monitoring | 0.1.4 |
 | file://../hyperswitch-ucs | hyperswitch-ucs | 0.1.2 |
 | file://../hyperswitch-web | hyperswitch-web | 0.2.12 |
 

--- a/charts/incubator/hyperswitch-stack/values.yaml
+++ b/charts/incubator/hyperswitch-stack/values.yaml
@@ -211,7 +211,7 @@ hyperswitch-monitoring:
 
 # @ignored
 hyperswitch-ucs:
-  enabled: true
+  enabled: false
   fullnameOverride: "hyperswitch-ucs"
   image:
     imageRegistry: ghcr.io


### PR DESCRIPTION
Disabling UCS chart in hyperswitch-stack chart by default.