### PR TITLE
fix: logs and metrics scrape for hyperswitch-monitoring stack

### DIFF
--- a/charts/incubator/hyperswitch-monitoring/Chart.yaml
+++ b/charts/incubator/hyperswitch-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyperswitch-monitoring
 description: Monitoring stack for Hyperswitch including Prometheus, Loki, Promtail, and Grafana
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.0.0"
 
 dependencies:

--- a/charts/incubator/hyperswitch-monitoring/values.yaml
+++ b/charts/incubator/hyperswitch-monitoring/values.yaml
@@ -49,6 +49,9 @@ kube-prometheus-stack:
       # Retention period
       retention: 30d
 
+      # Disable the default behavior of auto-adding release label selector
+      # This allows Prometheus to discover all ServiceMonitors without label matching
+      serviceMonitorSelectorNilUsesHelmValues: false
       # Empty selector - discovers all ServiceMonitors in allowed namespaces
       serviceMonitorSelector: {}
 
@@ -229,7 +232,7 @@ promtail:
       # Extra relabel configs to filter hyperswitch pods
       extraRelabelConfigs:
         - action: "keep"
-          regex: "hyperswitch-.*"
+          regex: "(hyperswitch-.*|.*-hyperswitch-.*)"
           source_labels: ["__meta_kubernetes_pod_label_app"]
 
 # OpenTelemetry Collector configuration


### PR DESCRIPTION
This pull request updates the `hyperswitch-monitoring` Helm chart with improvements to monitoring configuration and log collection. The most notable changes are an expanded Promtail pod selection and a configuration tweak to Prometheus service discovery.

**Monitoring configuration improvements:**

* Updated the chart version in `Chart.yaml` from `0.1.5` to `0.1.6` to reflect the new changes.
* Set `serviceMonitorSelectorNilUsesHelmValues: false` in `values.yaml` to ensure Prometheus discovers all `ServiceMonitors` without requiring a label match, broadening monitoring coverage.

**Log collection enhancements:**

* Modified Promtail's `extraRelabelConfigs` regex to match more pod name patterns (`(hyperswitch-.*|.*-hyperswitch-.*)`), enabling log collection from a wider set of pods related to Hyperswitch.