### PR TITLE
chore: update hyperswitch-card-vault helm chart to suppport v0.7.0

### DIFF
--- a/charts/incubator/hyperswitch-card-vault/Chart.yaml
+++ b/charts/incubator/hyperswitch-card-vault/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/incubator/hyperswitch-card-vault/Chart.yaml
+++ b/charts/incubator/hyperswitch-card-vault/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.6
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "0.7.0"
 
 dependencies:
   - name: postgresql

--- a/charts/incubator/hyperswitch-card-vault/README.md
+++ b/charts/incubator/hyperswitch-card-vault/README.md
@@ -1,6 +1,6 @@
 # hyperswitch-card-vault
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 "application"
 A Helm chart for creating Hyperswitch Card Vault
@@ -159,26 +159,25 @@ external:
 | secrets.aws.key_id | string | `""` |  |
 | secrets.aws.region | string | `"us-east-1"` |  |
 | secrets.database.password | string | `"dummyPassword"` |  |
-| secrets.external_key_manager.cert | string | `""` |  |
+| secrets.external_key_manager.caCert | string | `""` |  |
 | secrets.locker_private_key | string | "-----BEGIN RSA PRIVATE KEY-----...-----END RSA PRIVATE KEY-----" | To create this key pairs, follow the instructions provided here: </br> # Generating the private keys <pre>openssl genrsa -out locker-private-key.pem 2048</pre> <pre>openssl genrsa -out tenant-private-key.pem 2048</pre> # Generating the public keys </br> <pre>openssl rsa -in locker-private-key.pem -pubout -out locker-public-key.pem</pre> <pre>openssl rsa -in tenant-private-key.pem -pubout -out tenant-public-key.pem</pre> The private key for the locker from locker-private-key.pem |
 | secrets.tls.certificate | string | `""` |  |
 | secrets.tls.private_key | string | `""` |  |
 | secrets.vault.token | string | `""` |  |
 | server.affinity | object | `{}` |  |
 | server.annotations | object | `{}` |  |
-| server.apiClient.identity | string | `""` |  |
 | server.awsKms.keyId | string | `""` |  |
 | server.awsKms.region | string | `""` |  |
-| server.externalKeyManager.cert | string | `""` |  |
-| server.externalKeyManager.url | string | `"http://localhost:5000"` |  |
+| server.external_key_manager.mode | string | `"disabled"` |  |
+| server.external_key_manager.url | string | `"http://localhost:5000"` |  |
 | server.extra.env | object | `{}` |  |
 | server.host | string | `"0.0.0.0"` |  |
-| server.image | string | `"juspaydotin/hyperswitch-card-vault:v0.6.5-dev"` |  |
+| server.image | string | `"juspaydotin/hyperswitch-card-vault:v0.7.0"` |  |
 | server.imageRegistry | string | `"docker.juspay.io"` |  |
 | server.pod.annotations | object | `{}` |  |
 | server.port | string | `"8080"` |  |
 | server.vault.url | string | `"http://127.0.0.1:8200"` |  |
-| server.version | string | `"v0.6.5"` |  |
+| server.version | string | `"v0.7.0"` |  |
 | tenant_secrets.public.master_key | string | `"8283d68fdbd89a78aef9bed8285ed1cd9310012f660eefbad865f20a3f3dd9498f06147da6a7d9b84677cafca95024990b3d2296fbafc55e10dd76df"` |  |
 | tenant_secrets.public.public_key | string | "-----BEGIN PUBLIC KEY-----...-----END PUBLIC KEY-----" | The public key for the tenant from tenant_secrets-public-public_key.pem |
 | tenant_secrets.public.schema | string | `"public"` |  |

--- a/charts/incubator/hyperswitch-card-vault/templates/_helpers.tpl
+++ b/charts/incubator/hyperswitch-card-vault/templates/_helpers.tpl
@@ -149,11 +149,11 @@ LOCKER server port
 {{- default "8080" .Values.server.port | quote }}
 {{- end }}
 
-{{- define "locker.externalKeyManager.url" -}}
-{{- default "http://localhost:5000" .Values.server.externalKeyManager.url -}}
+{{- define "locker.external_key_manager.url" -}}
+{{- default "http://localhost:5000" .Values.server.external_key_manager.url -}}
 {{- end -}}
 
-{{- define "locker.externalKeyManager.caCert" -}}
+{{- define "locker.external_key_manager.caCert" -}}
 {{- default "" .Values.secrets.external_key_manager.caCert -}}
 {{- end -}}
 
@@ -229,7 +229,7 @@ false
 Check if external key manager mTLS is enabled
 */}}
 {{- define "locker.externalKeyManagerMtlsEnabled" -}}
-{{- if eq .Values.server.externalKeyManager.mode "enabled_with_mtls" -}}
+{{- if eq .Values.server.external_key_manager.mode "enabled_with_mtls" -}}
 true
 {{- else -}}
 false

--- a/charts/incubator/hyperswitch-card-vault/templates/_helpers.tpl
+++ b/charts/incubator/hyperswitch-card-vault/templates/_helpers.tpl
@@ -153,12 +153,12 @@ LOCKER server port
 {{- default "http://localhost:5000" .Values.server.externalKeyManager.url -}}
 {{- end -}}
 
-{{- define "locker.externalKeyManager.cert" -}}
-{{- default "dummyCert" .Values.server.externalKeyManager.cert -}}
+{{- define "locker.externalKeyManager.caCert" -}}
+{{- default "" .Values.secrets.external_key_manager.caCert -}}
 {{- end -}}
 
 {{- define "locker.apiClient.identity" -}}
-{{- default "dummyCert" .Values.server.apiClient.identity -}}
+{{- default "" .Values.secrets.api_client.identity -}}
 {{- end -}}
 
 {{- define "locker.awsKms.keyId" -}}
@@ -229,7 +229,7 @@ false
 Check if external key manager mTLS is enabled
 */}}
 {{- define "locker.externalKeyManagerMtlsEnabled" -}}
-{{- if .Values.secrets.external_key_manager.cert -}}
+{{- if eq .Values.server.externalKeyManager.mode "enabled_with_mtls" -}}
 true
 {{- else -}}
 false

--- a/charts/incubator/hyperswitch-card-vault/templates/configmap.yaml
+++ b/charts/incubator/hyperswitch-card-vault/templates/configmap.yaml
@@ -21,20 +21,20 @@ data:
     private_key = "{{ .Values.server.tls.privateKey }}"
     {{- end }}
     
-    {{- if eq .Values.server.externalKeyManager.mode "enabled_with_mtls" }}
+    {{- if eq .Values.server.external_key_manager.mode "enabled_with_mtls" }}
     
     [external_key_manager]
     mode = "enabled_with_mtls"
-    url = "{{ .Values.server.externalKeyManager.url }}"
+    url = "{{ .Values.server.external_key_manager.url }}"
     
     [api_client]
     client_idle_timeout = 90
     pool_max_idle_per_host = 10
-    {{- else if eq .Values.server.externalKeyManager.mode "enabled" }}
+    {{- else if eq .Values.server.external_key_manager.mode "enabled" }}
     
     [external_key_manager]
     mode = "enabled"
-    url = "{{ .Values.server.externalKeyManager.url }}"
+    url = "{{ .Values.server.external_key_manager.url }}"
     
     [api_client]
     client_idle_timeout = 90

--- a/charts/incubator/hyperswitch-card-vault/templates/configmap.yaml
+++ b/charts/incubator/hyperswitch-card-vault/templates/configmap.yaml
@@ -21,20 +21,28 @@ data:
     private_key = "{{ .Values.server.tls.privateKey }}"
     {{- end }}
     
-    {{- if eq (include "locker.externalKeyManagerMtlsEnabled" .) "true" }}
+    {{- if eq .Values.server.externalKeyManager.mode "enabled_with_mtls" }}
     
     [external_key_manager]
+    mode = "enabled_with_mtls"
     url = "{{ .Values.server.externalKeyManager.url }}"
-    cert = "{{ .Values.server.externalKeyManager.cert }}"
     
     [api_client]
     client_idle_timeout = 90
     pool_max_idle_per_host = 10
-    identity = "{{ .Values.server.apiClient.identity }}"
+    {{- else if eq .Values.server.externalKeyManager.mode "enabled" }}
+    
+    [external_key_manager]
+    mode = "enabled"
+    url = "{{ .Values.server.externalKeyManager.url }}"
+    
+    [api_client]
+    client_idle_timeout = 90
+    pool_max_idle_per_host = 10
     {{- else }}
     
     [external_key_manager]
-    url = "{{ .Values.server.externalKeyManager.url }}"
+    mode = "disabled"
     
     [api_client]
     client_idle_timeout = 90

--- a/charts/incubator/hyperswitch-card-vault/templates/deployment.yaml
+++ b/charts/incubator/hyperswitch-card-vault/templates/deployment.yaml
@@ -116,14 +116,16 @@ spec:
               value: "5000"
             - name: LOCKER__CACHE__TTI
               value: "7200"
+            - name: LOCKER__EXTERNAL_KEY_MANAGER__MODE
+              value: {{ .Values.server.external_key_manager.mode | quote }}
             - name: LOCKER__EXTERNAL_KEY_MANAGER__URL
-              value: {{ .Values.server.externalKeyManager.url | quote }}
-            {{- if .Values.secrets.external_key_manager.cert }}
-            - name: LOCKER__EXTERNAL_KEY_MANAGER__CERT
+              value: {{ .Values.server.external_key_manager.url | quote }}
+            {{- if .Values.secrets.external_key_manager.caCert }}
+            - name: LOCKER__EXTERNAL_KEY_MANAGER__CA_CERT
               valueFrom:
                 secretKeyRef:
                   name: locker-secrets-{{ .Release.Name }}
-                  key: LOCKER__EXTERNAL_KEY_MANAGER__CERT
+                  key: LOCKER__EXTERNAL_KEY_MANAGER__CA_CERT
             {{- end }}
             {{- if .Values.secrets.api_client.identity }}
             - name: LOCKER__API_CLIENT__IDENTITY

--- a/charts/incubator/hyperswitch-card-vault/templates/secrets.yaml
+++ b/charts/incubator/hyperswitch-card-vault/templates/secrets.yaml
@@ -19,7 +19,7 @@ data:
   LOCKER__TLS__PRIVATE_KEY: {{ .Values.secrets.tls.private_key | b64enc }}
   {{- end }}
   
-  {{- if eq .Values.server.externalKeyManager.mode "enabled_with_mtls" }}
+  {{- if eq .Values.server.external_key_manager.mode "enabled_with_mtls" }}
   {{- if .Values.secrets.external_key_manager.caCert }}
   LOCKER__EXTERNAL_KEY_MANAGER__CA_CERT: {{ .Values.secrets.external_key_manager.caCert | b64enc }}
   {{- end }}

--- a/charts/incubator/hyperswitch-card-vault/templates/secrets.yaml
+++ b/charts/incubator/hyperswitch-card-vault/templates/secrets.yaml
@@ -19,12 +19,13 @@ data:
   LOCKER__TLS__PRIVATE_KEY: {{ .Values.secrets.tls.private_key | b64enc }}
   {{- end }}
   
-  {{- if .Values.secrets.external_key_manager.cert }}
-  LOCKER__EXTERNAL_KEY_MANAGER__CERT: {{ .Values.secrets.external_key_manager.cert | b64enc }}
+  {{- if eq .Values.server.externalKeyManager.mode "enabled_with_mtls" }}
+  {{- if .Values.secrets.external_key_manager.caCert }}
+  LOCKER__EXTERNAL_KEY_MANAGER__CA_CERT: {{ .Values.secrets.external_key_manager.caCert | b64enc }}
   {{- end }}
-  
   {{- if .Values.secrets.api_client.identity }}
   LOCKER__API_CLIENT__IDENTITY: {{ .Values.secrets.api_client.identity | b64enc }}
+  {{- end }}
   {{- end }}
 kind: Secret
 metadata:

--- a/charts/incubator/hyperswitch-card-vault/values.yaml
+++ b/charts/incubator/hyperswitch-card-vault/values.yaml
@@ -50,7 +50,7 @@ server:
     # extra env variables to be added to hyperswitch-card-vault.
     env: {}
 
-  externalKeyManager:
+  external_key_manager:
     # Mode options: "disabled", "enabled", "enabled_with_mtls"
     # - disabled: External key manager is not used
     # - enabled: External key manager is used without mTLS

--- a/charts/incubator/hyperswitch-card-vault/values.yaml
+++ b/charts/incubator/hyperswitch-card-vault/values.yaml
@@ -23,10 +23,10 @@ server:
   #   eks.amazonaws.com/role-arn: "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
   host: "0.0.0.0"
   port: "8080"
-  version: v0.6.5
+  version: v0.7.0
   # Image registry and name for hyperswitch-card-vault.
   imageRegistry: docker.juspay.io
-  image: juspaydotin/hyperswitch-card-vault:v0.6.5-dev
+  image: juspaydotin/hyperswitch-card-vault:v0.7.0
 
   # values to be used in pod template.
   pod:
@@ -51,11 +51,12 @@ server:
     env: {}
 
   externalKeyManager:
+    # Mode options: "disabled", "enabled", "enabled_with_mtls"
+    # - disabled: External key manager is not used
+    # - enabled: External key manager is used without mTLS
+    # - enabled_with_mtls: External key manager is used with mTLS (requires secrets.external_key_manager.caCert and secrets.api_client.identity)
+    mode: "disabled"
     url: "http://localhost:5000"
-    cert: ""
-
-  apiClient:
-    identity: ""
 
   awsKms:
     keyId: ""
@@ -129,13 +130,13 @@ secrets:
     certificate: ""  # TLS certificate content
     private_key: ""  # TLS private key content
 
-  # External key manager mTLS certificates (optional)
+  # External key manager mTLS certificates (required when server.externalKeyManager.mode is "enabled_with_mtls")
   external_key_manager:
-    cert: ""  # Certificate for external key manager mTLS
+    caCert: ""
 
-  # API client mTLS identity (optional)
+  # API client mTLS identity (required when server.externalKeyManager.mode is "enabled_with_mtls")
   api_client:
-    identity: ""  # Client identity for mTLS authentication
+    identity: ""
 
 # Tenant configuration
 tenant_secrets:


### PR DESCRIPTION
This pull request refactors the configuration and secret management for the external key manager integration in the `hyperswitch-card-vault` Helm chart. The main focus is to provide more explicit control over the external key manager's mode (disabled, enabled, or enabled with mTLS), clarify required secrets, and update the chart and application versions accordingly.

**External Key Manager Integration Refactor:**

* Added a new `mode` field (`disabled`, `enabled`, `enabled_with_mtls`) to `server.externalKeyManager` in `values.yaml` to control the external key manager's activation and mTLS usage, and updated documentation for clarity.
* Replaced the single `cert` field with `caCert` for the external key manager's mTLS CA certificate in `values.yaml` and `secrets.yaml`, and clarified when these secrets are required. [[1]](diffhunk://#diff-cf87217166d3aec9643c8a09dfd2e041014392bff9fe41c98287e3d0358532b2L132-R139) [[2]](diffhunk://#diff-59a926b29b52557ad37960436928c71c97e37d1134166f2fd7f2d3828ff47615L22-R29)
* Updated the config map and secret templates to generate configuration and secrets based on the selected external key manager mode, ensuring correct fields are set for each mode and avoiding unnecessary fields when mTLS is not enabled. [[1]](diffhunk://#diff-228b47924007568f7fcfd7b677995da15fb27b31d47d78cfba62bb1508924b0dL24-R46) [[2]](diffhunk://#diff-59a926b29b52557ad37960436928c71c97e37d1134166f2fd7f2d3828ff47615L22-R29) [[3]](diffhunk://#diff-144492fa05c3ee70610fa8d71c374ef1b954dee1bf58615a3f17ce69054b701dL156-R161) [[4]](diffhunk://#diff-144492fa05c3ee70610fa8d71c374ef1b954dee1bf58615a3f17ce69054b701dL232-R232)

**Version Updates:**

* Bumped the chart version to `0.1.6` and the application version to `0.7.0` in `Chart.yaml` and updated the image tag in `values.yaml` to match. [[1]](diffhunk://#diff-e2fee758f62f6b27f2981d2d30df9bd9b2cbc7df9726d88b296a345475b1b784L18-R24) [[2]](diffhunk://#diff-cf87217166d3aec9643c8a09dfd2e041014392bff9fe41c98287e3d0358532b2L26-R29)

These changes make the configuration more robust, easier to understand, and less error-prone when enabling or disabling the external key manager and its mTLS features.