### PR TITLE
chore: bump hyperswitch-stack to 0.2.21

### DIFF
--- a/charts/incubator/hyperswitch-stack/Chart.yaml
+++ b/charts/incubator/hyperswitch-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.20
+version: 0.2.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,14 +24,14 @@ version: 0.2.20
 appVersion: "1.16.0"
 dependencies:
   - name: hyperswitch-app
-    version: 1.1.0
-    repository: "https://juspay.github.io/hyperswitch-helm"
+    version: 1.1.2
+    repository: "file://../hyperswitch-app"
   - name: hyperswitch-web
     version: 0.2.12
     repository: "https://juspay.github.io/hyperswitch-helm"
     condition: hyperswitch-web.enabled
   - name: hyperswitch-monitoring
-    version: 0.1.5
+    version: 0.1.6
     repository: "https://juspay.github.io/hyperswitch-helm"
     condition: hyperswitch-monitoring.enabled
   - name: hyperswitch-ucs

--- a/charts/incubator/hyperswitch-stack/Chart.yaml
+++ b/charts/incubator/hyperswitch-stack/Chart.yaml
@@ -24,8 +24,8 @@ version: 0.2.21
 appVersion: "1.16.0"
 dependencies:
   - name: hyperswitch-app
-    version: 1.1.2
-    repository: "file://../hyperswitch-app"
+    version: 1.1.1
+    repository: "https://juspay.github.io/hyperswitch-helm"
   - name: hyperswitch-web
     version: 0.2.12
     repository: "https://juspay.github.io/hyperswitch-helm"

--- a/charts/incubator/hyperswitch-stack/README.md
+++ b/charts/incubator/hyperswitch-stack/README.md
@@ -215,7 +215,7 @@ task ur
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../hyperswitch-app | hyperswitch-app | 1.1.2 |
+| https://juspay.github.io/hyperswitch-helm | hyperswitch-app | 1.1.1 |
 | https://juspay.github.io/hyperswitch-helm | hyperswitch-control-center | 1.1.0 |
 | https://juspay.github.io/hyperswitch-helm | hyperswitch-monitoring | 0.1.6 |
 | https://juspay.github.io/hyperswitch-helm | hyperswitch-ucs | 0.1.2 |

--- a/charts/incubator/hyperswitch-stack/README.md
+++ b/charts/incubator/hyperswitch-stack/README.md
@@ -215,8 +215,8 @@ task ur
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://juspay.github.io/hyperswitch-helm | hyperswitch-app | 1.1.0 |
+| file://../hyperswitch-app | hyperswitch-app | 1.1.2 |
 | https://juspay.github.io/hyperswitch-helm | hyperswitch-control-center | 1.1.0 |
-| https://juspay.github.io/hyperswitch-helm | hyperswitch-monitoring | 0.1.5 |
+| https://juspay.github.io/hyperswitch-helm | hyperswitch-monitoring | 0.1.6 |
 | https://juspay.github.io/hyperswitch-helm | hyperswitch-ucs | 0.1.2 |
 | https://juspay.github.io/hyperswitch-helm | hyperswitch-web | 0.2.12 |

--- a/charts/incubator/hyperswitch-stack/values.yaml
+++ b/charts/incubator/hyperswitch-stack/values.yaml
@@ -130,6 +130,9 @@ hyperswitch-app:
     run_env: sandbox
     email:
       active_email_client: SMTP
+    configs:
+      proxy:
+        enabled: false
   controlCenter:
     env:
       default__features__email: "true"


### PR DESCRIPTION
This pull request updates the `hyperswitch-stack` Helm chart to use newer dependency versions and introduces a new configuration option for the `hyperswitch-app` component. The most important changes are grouped below:

Dependency version updates:

* Updated the `hyperswitch-app` dependency to version `1.1.2` and changed its repository to a local file path (`file://../hyperswitch-app`) in both `Chart.yaml` and `README.md`. [[1]](diffhunk://#diff-857824a571b4886e9956119e8d8c43f4ccade180eceee9697e20eeed46db1447L27-R34) [[2]](diffhunk://#diff-0dfbe97b12e24de6a763c2cc9921fc4aff69abad8b0c1079cc4e0113ff704649L218-R220)
* Bumped the `hyperswitch-monitoring` dependency version from `0.1.5` to `0.1.6` in both `Chart.yaml` and `README.md`. [[1]](diffhunk://#diff-857824a571b4886e9956119e8d8c43f4ccade180eceee9697e20eeed46db1447L27-R34) [[2]](diffhunk://#diff-0dfbe97b12e24de6a763c2cc9921fc4aff69abad8b0c1079cc4e0113ff704649L218-R220)
* Updated the overall chart version from `0.2.20` to `0.2.21`.

Configuration enhancements:

* Added a new `configs.proxy.enabled` flag (default `false`) under the `hyperswitch-app` configuration section in `values.yaml`, allowing proxy configuration to be toggled.