### PR TITLE
feat(hyperswitch-app_pvc): add pvc creation template and support for superposition backup efs file system

### DIFF
--- a/charts/incubator/hyperswitch-app/templates/consumer/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/consumer/deployment.yaml
@@ -118,6 +118,11 @@ spec:
               name: hyperswitch-config
               subPath: router.toml
             {{- end }}
+            {{- if .Values.efs.enabled }}
+            - mountPath: {{ .Values.efs.mountPath | default "/mnt/data" }}
+              name: superposition-config-backup
+              readOnly: true
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -129,4 +134,9 @@ spec:
             defaultMode: 420
             name: router-cm-{{ .Release.Name }}
           name: hyperswitch-config
+        {{- if .Values.efs.enabled }}
+        - name: superposition-config-backup
+          persistentVolumeClaim:
+            claimName: {{ .Values.efs.pvcName }}
+        {{- end }}
 {{- end }}

--- a/charts/incubator/hyperswitch-app/templates/consumer/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/consumer/deployment.yaml
@@ -118,9 +118,9 @@ spec:
               name: hyperswitch-config
               subPath: router.toml
             {{- end }}
-            {{- if .Values.efs.enabled }}
-            - mountPath: {{ .Values.efs.mountPath | default "/mnt/data" }}
-              name: superposition-config-backup
+            {{- if .Values.superposition_fallback_efs.enabled }}
+            - mountPath: {{ .Values.superposition_fallback_efs.mountPath | default "/mnt/data" }}
+              name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
               readOnly: true
             {{- end }}
       dnsPolicy: ClusterFirst
@@ -134,9 +134,9 @@ spec:
             defaultMode: 420
             name: router-cm-{{ .Release.Name }}
           name: hyperswitch-config
-        {{- if .Values.efs.enabled }}
-        - name: superposition-config-backup
+        {{- if .Values.superposition_fallback_efs.enabled }}
+        - name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
           persistentVolumeClaim:
-            claimName: {{ .Values.efs.pvcName }}
+            claimName: {{ .Values.superposition_fallback_efs.pvcName }}
         {{- end }}
 {{- end }}

--- a/charts/incubator/hyperswitch-app/templates/drainer/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/drainer/deployment.yaml
@@ -97,5 +97,17 @@ spec:
             - secretRef:
                 name: drainer-secret-{{ .Release.Name }}
           {{- end }}
+          {{- if .Values.efs.enabled }}
+          volumeMounts:
+            - mountPath: {{ .Values.efs.mountPath | default "/mnt/data" }}
+              name: superposition-config-backup
+              readOnly: true
+          {{- end }}
+      volumes:
+        {{- if .Values.efs.enabled }}
+        - name: superposition-config-backup
+          persistentVolumeClaim:
+            claimName: {{ .Values.efs.pvcName }}
+        {{- end }}
       serviceAccountName: {{ include "hyperswitch-router-sa.name" . }}
 {{- end }}

--- a/charts/incubator/hyperswitch-app/templates/drainer/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/drainer/deployment.yaml
@@ -97,17 +97,17 @@ spec:
             - secretRef:
                 name: drainer-secret-{{ .Release.Name }}
           {{- end }}
-          {{- if .Values.efs.enabled }}
+          {{- if .Values.superposition_fallback_efs.enabled }}
           volumeMounts:
-            - mountPath: {{ .Values.efs.mountPath | default "/mnt/data" }}
-              name: superposition-config-backup
+            - mountPath: {{ .Values.superposition_fallback_efs.mountPath | default "/mnt/data" }}
+              name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
               readOnly: true
           {{- end }}
       volumes:
-        {{- if .Values.efs.enabled }}
-        - name: superposition-config-backup
+        {{- if .Values.superposition_fallback_efs.enabled }}
+        - name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
           persistentVolumeClaim:
-            claimName: {{ .Values.efs.pvcName }}
+            claimName: {{ .Values.superposition_fallback_efs.pvcName }}
         {{- end }}
       serviceAccountName: {{ include "hyperswitch-router-sa.name" . }}
 {{- end }}

--- a/charts/incubator/hyperswitch-app/templates/misc/pvc.yaml
+++ b/charts/incubator/hyperswitch-app/templates/misc/pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.efs.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.efs.pvcName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hyperswitch.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ .Values.efs.storageClassName }}
+  resources:
+    requests:
+      storage: {{ .Values.efs.storage }}
+{{- end }}

--- a/charts/incubator/hyperswitch-app/templates/misc/pvc.yaml
+++ b/charts/incubator/hyperswitch-app/templates/misc/pvc.yaml
@@ -1,16 +1,16 @@
-{{- if .Values.efs.enabled }}
+{{- if .Values.superposition_fallback_efs.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.efs.pvcName }}
+  name: {{ .Values.superposition_fallback_efs.pvcName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "hyperswitch.labels" . | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: {{ .Values.efs.storageClassName }}
+  storageClassName: {{ .Values.superposition_fallback_efs.storageClassName }}
   resources:
     requests:
-      storage: {{ .Values.efs.storage }}
+      storage: {{ .Values.superposition_fallback_efs.storage }}
 {{- end }}

--- a/charts/incubator/hyperswitch-app/templates/producer/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/producer/deployment.yaml
@@ -118,6 +118,11 @@ spec:
               name: hyperswitch-config
               subPath: router.toml
             {{- end }}
+            {{- if .Values.efs.enabled }}
+            - mountPath: {{ .Values.efs.mountPath | default "/mnt/data" }}
+              name: superposition-config-backup
+              readOnly: true
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -129,4 +134,9 @@ spec:
             defaultMode: 420
             name: router-cm-{{.Release.Name }}
           name: hyperswitch-config
+        {{- if .Values.efs.enabled }}
+        - name: superposition-config-backup
+          persistentVolumeClaim:
+            claimName: {{ .Values.efs.pvcName }}
+        {{- end }}
 {{- end }}

--- a/charts/incubator/hyperswitch-app/templates/producer/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/producer/deployment.yaml
@@ -118,9 +118,9 @@ spec:
               name: hyperswitch-config
               subPath: router.toml
             {{- end }}
-            {{- if .Values.efs.enabled }}
-            - mountPath: {{ .Values.efs.mountPath | default "/mnt/data" }}
-              name: superposition-config-backup
+            {{- if .Values.superposition_fallback_efs.enabled }}
+            - mountPath: {{ .Values.superposition_fallback_efs.mountPath | default "/mnt/data" }}
+              name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
               readOnly: true
             {{- end }}
       dnsPolicy: ClusterFirst
@@ -134,9 +134,9 @@ spec:
             defaultMode: 420
             name: router-cm-{{.Release.Name }}
           name: hyperswitch-config
-        {{- if .Values.efs.enabled }}
-        - name: superposition-config-backup
+        {{- if .Values.superposition_fallback_efs.enabled }}
+        - name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
           persistentVolumeClaim:
-            claimName: {{ .Values.efs.pvcName }}
+            claimName: {{ .Values.superposition_fallback_efs.pvcName }}
         {{- end }}
 {{- end }}

--- a/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
@@ -190,6 +190,11 @@ spec:
               name: router-config
               subPath: router.toml
             {{- end }}
+            {{- if .Values.efs.enabled }}
+            - mountPath: {{ .Values.efs.mountPath | default "/mnt/data" }}
+              name: superposition-config-backup
+              readOnly: true
+            {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -201,4 +206,9 @@ spec:
             defaultMode: 420
             name: router-cm-{{.Release.Name }}
           name: router-config
+        {{- if .Values.efs.enabled }}
+        - name: superposition-config-backup
+          persistentVolumeClaim:
+            claimName: {{ .Values.efs.pvcName }}
+        {{- end }}
 {{- end }}

--- a/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
@@ -190,9 +190,9 @@ spec:
               name: router-config
               subPath: router.toml
             {{- end }}
-            {{- if .Values.efs.enabled }}
-            - mountPath: {{ .Values.efs.mountPath | default "/mnt/data" }}
-              name: superposition-config-backup
+            {{- if .Values.superposition_fallback_efs.enabled }}
+            - mountPath: {{ .Values.superposition_fallback_efs.mountPath | default "/mnt/data" }}
+              name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
               readOnly: true
             {{- end }}
       dnsPolicy: ClusterFirst
@@ -206,9 +206,9 @@ spec:
             defaultMode: 420
             name: router-cm-{{.Release.Name }}
           name: router-config
-        {{- if .Values.efs.enabled }}
-        - name: superposition-config-backup
+        {{- if .Values.superposition_fallback_efs.enabled }}
+        - name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
           persistentVolumeClaim:
-            claimName: {{ .Values.efs.pvcName }}
+            claimName: {{ .Values.superposition_fallback_efs.pvcName }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
# Use the default volume name (empty = falls back to "superposition-config-backup")
superposition_fallback_efs:
  enabled: true
  pvcName: "superposition-config-backup"

# Or override the volume name explicitly
superposition_fallback_efs:
  enabled: true
  pvcName: "superposition-config-backup"
  volumeName: "my-custom-volume-name"