### PR TITLE
feat(hyperswitch-app - cronJob): add cronjob template for superposition fallback support

### DIFF
--- a/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
+++ b/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.superposition_fallback_efs.enabled }}
+---
+# Kubernetes CronJob for Superposition Config Backup
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.superposition_fallback_efs.cronjob.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hyperswitch.labels" . | nindent 4 }}
+    app: {{ .Values.superposition_fallback_efs.cronjob.name }}
+spec:
+  schedule: {{ .Values.superposition_fallback_efs.cronjob.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.superposition_fallback_efs.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.superposition_fallback_efs.cronjob.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ .Values.superposition_fallback_efs.cronjob.activeDeadlineSeconds }}
+      backoffLimit: {{ .Values.superposition_fallback_efs.cronjob.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            app: {{ .Values.superposition_fallback_efs.cronjob.name }}
+            {{- include "hyperswitch.labels" . | nindent 12 }}
+        spec:
+          hostNetwork: {{ .Values.superposition_fallback_efs.cronjob.hostNetwork }}
+          restartPolicy: {{ .Values.superposition_fallback_efs.cronjob.restartPolicy }}
+          securityContext:
+            runAsNonRoot: {{ .Values.superposition_fallback_efs.cronjob.securityContext.runAsNonRoot }}
+            runAsUser: {{ .Values.superposition_fallback_efs.cronjob.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.superposition_fallback_efs.cronjob.securityContext.runAsGroup }}
+            fsGroup: {{ .Values.superposition_fallback_efs.cronjob.securityContext.fsGroup }}
+          containers:
+            - name: superposition-config-backup
+              image: {{ .Values.superposition_fallback_efs.cronjob.image }}
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: SUPERPOSITION_ENDPOINT
+                  value: {{ .Values.superposition_fallback_efs.cronjob.superpositon.endpoint | quote }}
+                - name: SUPERPOSITION_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.superposition_fallback_efs.cronjob.superpositon.tokenSecretName }}
+                      key: {{ .Values.superposition_fallback_efs.cronjob.superpositon.tokenSecretKey }}
+                - name: SUPERPOSITION_ORG_ID
+                  value: {{ .Values.superposition_fallback_efs.cronjob.superpositon.orgId | quote }}
+                - name: SUPERPOSITION_WORKSPACE_ID
+                  value: {{ .Values.superposition_fallback_efs.cronjob.superpositon.workspaceId | quote }}
+                - name: EFS_MOUNT_PATH
+                  value: {{ .Values.superposition_fallback_efs.mountPath | default "/mnt/data" | quote }}
+                - name: RETENTION_COUNT
+                  value: {{ .Values.superposition_fallback_efs.cronjob.retentionCount | quote }}
+                - name: RUN_ONCE
+                  value: {{ .Values.superposition_fallback_efs.cronjob.runOnce | quote }}
+              volumeMounts:
+                - name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
+                  mountPath: {{ .Values.superposition_fallback_efs.mountPath | default "/mnt/data" }}
+                  readOnly: false
+              resources:
+                {{- toYaml .Values.superposition_fallback_efs.cronjob.resources | nindent 16 }}
+          volumes:
+            - name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
+              persistentVolumeClaim:
+                claimName: {{ .Values.superposition_fallback_efs.pvcName }}
+{{- end }}

--- a/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
+++ b/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
@@ -32,7 +32,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: superposition-config-backup-cronjob
-              image: {{ .Values.superposition_fallback_cronjob.image | default "ghcr.io/srujanchikke/superposition-config-backup:latest" }}
+              image: {{ .Values.superposition_fallback_cronjob.image | default "" }}
               imagePullPolicy: {{ .Values.superposition_fallback_cronjob.imagePullPolicy | default "IfNotPresent" }}
               env:
                 - name: SUPERPOSITION_ENDPOINT

--- a/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
+++ b/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
@@ -1,66 +1,63 @@
-{{- if .Values.superposition_fallback_efs.enabled }}
+{{- if and .Values.superposition_fallback_efs.enabled .Values.superposition_fallback_cronjob.enabled }}
 ---
 # Kubernetes CronJob for Superposition Config Backup
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Values.superposition_fallback_efs.cronjob.name }}
+  name: {{ .Values.superposition_fallback_cronjob.name | default "superposition-config-backup" }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "hyperswitch.labels" . | nindent 4 }}
-    app: {{ .Values.superposition_fallback_efs.cronjob.name }}
+    app: {{ .Values.superposition_fallback_cronjob.name | default "superposition-config-backup" }}
 spec:
-  schedule: {{ .Values.superposition_fallback_efs.cronjob.schedule | quote }}
+  schedule: {{ .Values.superposition_fallback_cronjob.schedule | default "* * * * *" | quote }}
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: {{ .Values.superposition_fallback_efs.cronjob.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ .Values.superposition_fallback_efs.cronjob.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.superposition_fallback_cronjob.successfulJobsHistoryLimit | default 3 }}
+  failedJobsHistoryLimit: {{ .Values.superposition_fallback_cronjob.failedJobsHistoryLimit | default 1 }}
   jobTemplate:
     spec:
-      activeDeadlineSeconds: {{ .Values.superposition_fallback_efs.cronjob.activeDeadlineSeconds }}
-      backoffLimit: {{ .Values.superposition_fallback_efs.cronjob.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.superposition_fallback_cronjob.activeDeadlineSeconds | default 300 }}
+      backoffLimit: {{ .Values.superposition_fallback_cronjob.backoffLimit | default 3 }}
       template:
         metadata:
           labels:
-            app: {{ .Values.superposition_fallback_efs.cronjob.name }}
+            app: {{ .Values.superposition_fallback_cronjob.name | default "superposition-config-backup" }}
             {{- include "hyperswitch.labels" . | nindent 12 }}
         spec:
-          hostNetwork: {{ .Values.superposition_fallback_efs.cronjob.hostNetwork }}
-          restartPolicy: {{ .Values.superposition_fallback_efs.cronjob.restartPolicy }}
+          restartPolicy: {{ .Values.superposition_fallback_cronjob.restartPolicy | default "OnFailure" }}
           securityContext:
-            runAsNonRoot: {{ .Values.superposition_fallback_efs.cronjob.securityContext.runAsNonRoot }}
-            runAsUser: {{ .Values.superposition_fallback_efs.cronjob.securityContext.runAsUser }}
-            runAsGroup: {{ .Values.superposition_fallback_efs.cronjob.securityContext.runAsGroup }}
-            fsGroup: {{ .Values.superposition_fallback_efs.cronjob.securityContext.fsGroup }}
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
           containers:
             - name: superposition-config-backup
-              image: {{ .Values.superposition_fallback_efs.cronjob.image }}
+              image: {{ .Values.superposition_fallback_cronjob.image | default "ghcr.io/srujanchikke/superposition-config-backup:latest" }}
               imagePullPolicy: IfNotPresent
               env:
                 - name: SUPERPOSITION_ENDPOINT
-                  value: {{ .Values.superposition_fallback_efs.cronjob.superpositon.endpoint | quote }}
+                  value: {{ .Values.superposition_fallback_cronjob.superpositon.endpoint | default "http://localhost:8080" | quote }}
                 - name: SUPERPOSITION_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.superposition_fallback_efs.cronjob.superpositon.tokenSecretName }}
-                      key: {{ .Values.superposition_fallback_efs.cronjob.superpositon.tokenSecretKey }}
+                      name: {{ .Values.superposition_fallback_cronjob.superpositon.tokenSecretName | default "superposition-config-backup-secret" }}
+                      key: {{ .Values.superposition_fallback_cronjob.superpositon.tokenSecretKey | default "token" }}
                 - name: SUPERPOSITION_ORG_ID
-                  value: {{ .Values.superposition_fallback_efs.cronjob.superpositon.orgId | quote }}
+                  value: {{ .Values.superposition_fallback_cronjob.superpositon.orgId | default "" | quote }}
                 - name: SUPERPOSITION_WORKSPACE_ID
-                  value: {{ .Values.superposition_fallback_efs.cronjob.superpositon.workspaceId | quote }}
+                  value: {{ .Values.superposition_fallback_cronjob.superpositon.workspaceId | default "" | quote }}
                 - name: EFS_MOUNT_PATH
                   value: {{ .Values.superposition_fallback_efs.mountPath | default "/mnt/data" | quote }}
                 - name: RETENTION_COUNT
-                  value: {{ .Values.superposition_fallback_efs.cronjob.retentionCount | quote }}
-                - name: RUN_ONCE
-                  value: {{ .Values.superposition_fallback_efs.cronjob.runOnce | quote }}
+                  value: {{ .Values.superposition_fallback_cronjob.retentionCount | default "10" | quote }}
               volumeMounts:
                 - name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
                   mountPath: {{ .Values.superposition_fallback_efs.mountPath | default "/mnt/data" }}
                   readOnly: false
               resources:
-                {{- toYaml .Values.superposition_fallback_efs.cronjob.resources | nindent 16 }}
+                {{- toYaml (.Values.superposition_fallback_cronjob.resources | default (dict "requests" (dict "memory" "32Mi" "cpu" "25m") "limits" (dict "memory" "64Mi" "cpu" "100m"))) | nindent 16 }}
           volumes:
             - name: {{ .Values.superposition_fallback_efs.volumeName | default "superposition-config-backup" }}
               persistentVolumeClaim:
-                claimName: {{ .Values.superposition_fallback_efs.pvcName }}
+                claimName: {{ .Values.superposition_fallback_efs.pvcName | default "superposition-config-backup" }}
 {{- end }}

--- a/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
+++ b/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
@@ -4,11 +4,11 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Values.superposition_fallback_cronjob.name | default "superposition-config-backup" }}
+  name: {{ .Values.superposition_fallback_cronjob.name | default "superposition-config-backup-cronjob" }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "hyperswitch.labels" . | nindent 4 }}
-    app: {{ .Values.superposition_fallback_cronjob.name | default "superposition-config-backup" }}
+    app: {{ .Values.superposition_fallback_cronjob.name | default "superposition-config-backup-cronjob" }}
 spec:
   schedule: {{ .Values.superposition_fallback_cronjob.schedule | default "* * * * *" | quote }}
   concurrencyPolicy: Forbid
@@ -21,7 +21,7 @@ spec:
       template:
         metadata:
           labels:
-            app: {{ .Values.superposition_fallback_cronjob.name | default "superposition-config-backup" }}
+            app: {{ .Values.superposition_fallback_cronjob.name | default "superposition-config-backup-cronjob" }}
             {{- include "hyperswitch.labels" . | nindent 12 }}
         spec:
           restartPolicy: {{ .Values.superposition_fallback_cronjob.restartPolicy | default "OnFailure" }}
@@ -31,17 +31,17 @@ spec:
             runAsGroup: 1000
             fsGroup: 1000
           containers:
-            - name: superposition-config-backup
+            - name: superposition-config-backup-cronjob
               image: {{ .Values.superposition_fallback_cronjob.image | default "ghcr.io/srujanchikke/superposition-config-backup:latest" }}
-              imagePullPolicy: IfNotPresent
+              imagePullPolicy: {{ .Values.superposition_fallback_cronjob.imagePullPolicy | default "IfNotPresent" }}
               env:
                 - name: SUPERPOSITION_ENDPOINT
-                  value: {{ .Values.superposition_fallback_cronjob.superpositon.endpoint | default "http://localhost:8080" | quote }}
+                  value: {{ .Values.superposition_fallback_cronjob.superpositon.endpoint | default "http://localhost:8081" | quote }}
                 - name: SUPERPOSITION_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.superposition_fallback_cronjob.superpositon.tokenSecretName | default "superposition-config-backup-secret" }}
-                      key: {{ .Values.superposition_fallback_cronjob.superpositon.tokenSecretKey | default "token" }}
+                      name: {{ .Values.superposition_fallback_cronjob.superpositon.tokenSecretName | default "hyperswitch-secrets" }}
+                      key: {{ .Values.superposition_fallback_cronjob.superpositon.tokenSecretKey | default "ROUTER__SUPERPOSITION__TOKEN" }}
                 - name: SUPERPOSITION_ORG_ID
                   value: {{ .Values.superposition_fallback_cronjob.superpositon.orgId | default "" | quote }}
                 - name: SUPERPOSITION_WORKSPACE_ID

--- a/charts/incubator/hyperswitch-app/values.yaml
+++ b/charts/incubator/hyperswitch-app/values.yaml
@@ -1891,11 +1891,60 @@ vector:
 
 # EFS PersistentVolumeClaim configuration for superposition fallback
 superposition_fallback_efs:
-  # -- Enable creation of an EFS-backed PVC for superposition config backup
+  # -- Enable creation of an EFS-backed PVC and volumeMounts in all pods
   enabled: false
+  # -- Name of the PersistentVolumeClaim to create and reference
+  pvcName: "superposition-config-backup"
+  # -- StorageClass to use for the PVC (must have an EFS CSI provisioner)
+  storageClassName: "efs-sc"
+  # -- Storage size for the PVC
+  storage: "1Gi"
+  # -- Mount path inside the containers for the EFS volume
+  mountPath: "/mnt/data"
 
 # CronJob configuration to sync superposition config into the EFS volume
 superposition_fallback_cronjob:
   # -- Enable the CronJob that syncs superposition config to EFS
   enabled: false
-
+  # -- Name of the CronJob resource
+  name: "superposition-config-backup-cronjob"
+  # -- Cron schedule (minimum Kubernetes CronJob interval is 1 minute)
+  schedule: "* * * * *"
+  # -- Container image for the backup job
+  image: "ghcr.io/srujanchikke/superposition-config-backup:latest"
+  # -- Image pull policy
+  imagePullPolicy: IfNotPresent
+  # -- Timeout for the job in seconds
+  activeDeadlineSeconds: 300
+  # -- Number of retries on pod failure
+  backoffLimit: 3
+  # -- Restart policy for the job pod
+  restartPolicy: OnFailure
+  # -- Number of successful job runs to retain in history
+  successfulJobsHistoryLimit: 3
+  # -- Number of failed job runs to retain in history
+  failedJobsHistoryLimit: 1
+  # -- Number of backup files to retain in EFS
+  retentionCount: "10"
+  # -- Superposition service connection details
+  superpositon:
+    # -- Superposition API endpoint URL
+    endpoint: "http://localhost:8081"
+    # -- Name of the Kubernetes Secret containing the Superposition API token.
+    #   tokenSecretName: "hyperswitch-secrets"
+    #   tokenSecretKey: "ROUTER__SUPERPOSITION__TOKEN"
+    tokenSecretName: "hyperswitch-secrets"
+    # -- Key within the secret that holds the token value
+    tokenSecretKey: "ROUTER__SUPERPOSITION__TOKEN"
+    # -- Superposition organisation ID (must match superposition.org_id)
+    orgId: ""
+    # -- Superposition workspace ID (must match superposition.workspace_id)
+    workspaceId: ""
+  # -- Resource requests and limits for the cronjob container
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "25m"
+    limits:
+      memory: "64Mi"
+      cpu: "100m"

--- a/charts/incubator/hyperswitch-app/values.yaml
+++ b/charts/incubator/hyperswitch-app/values.yaml
@@ -1893,3 +1893,9 @@ vector:
 superposition_fallback_efs:
   # -- Enable creation of an EFS-backed PVC for superposition config backup
   enabled: false
+
+# CronJob configuration to sync superposition config into the EFS volume
+superposition_fallback_cronjob:
+  # -- Enable the CronJob that syncs superposition config to EFS
+  enabled: false
+

--- a/charts/incubator/hyperswitch-app/values.yaml
+++ b/charts/incubator/hyperswitch-app/values.yaml
@@ -1911,7 +1911,7 @@ superposition_fallback_cronjob:
   # -- Cron schedule (minimum Kubernetes CronJob interval is 1 minute)
   schedule: "* * * * *"
   # -- Container image for the backup job
-  image: "ghcr.io/srujanchikke/superposition-config-backup:latest"
+  image: ""
   # -- Image pull policy
   imagePullPolicy: IfNotPresent
   # -- Timeout for the job in seconds


### PR DESCRIPTION
**_Summary_**
Adds a Kubernetes CronJob to the hyperswitch-app Helm chart that periodically syncs Superposition configuration into an EFS-backed volume, providing a local fallback in case the Superposition service becomes unreachable.

Changes
New: templates/misc/cronjob.yaml
Introduces a new CronJob template with the following characteristics:

Dual-gated rendering — the resource is only rendered when both superposition_fallback_efs.enabled: true and superposition_fallback_cronjob.enabled: true are set. This allows the EFS PVC/volume mounts to be enabled independently without necessarily running the sync job.
Schedule — defaults to "* * * * *" (every 1 minute — the minimum Kubernetes CronJob granularity). Fully overridable via values.
concurrencyPolicy: Forbid — prevents overlapping runs if a previous job is still in progress.
Hardcoded securityContext — runs as non-root (runAsNonRoot: true, runAsUser/Group: 1000, fsGroup: 1000) and is not configurable via values to enforce a consistent security posture.
Environment variables — only mandatory env vars are injected: SUPERPOSITION_ENDPOINT, SUPERPOSITION_TOKEN (from a Kubernetes secret), SUPERPOSITION_ORG_ID, SUPERPOSITION_WORKSPACE_ID, EFS_MOUNT_PATH, and RETENTION_COUNT.
Superposition token — read from a secretKeyRef (secret must be pre-created; not managed by this chart).
All values have | default fallbacks — the chart renders safely even with a minimal override, no nil-pointer errors during helm template.

Updated: 
Adds a new top-level superposition_fallback_cronjob block (separate from superposition_fallback_efs) with sensible defaults for all fields.