### PR TITLE
chore( hyperswitch-app - cronjob ): remove the activeDeadlineSeconds and backoffLimit fields from the superposition-fallback cronjob

### DIFF
--- a/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
+++ b/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
@@ -16,8 +16,6 @@ spec:
   failedJobsHistoryLimit: {{ .Values.superposition_fallback_cronjob.failedJobsHistoryLimit | default 1 }}
   jobTemplate:
     spec:
-      activeDeadlineSeconds: {{ .Values.superposition_fallback_cronjob.activeDeadlineSeconds | default 300 }}
-      backoffLimit: {{ .Values.superposition_fallback_cronjob.backoffLimit | default 3 }}
       template:
         metadata:
           labels:

--- a/charts/incubator/hyperswitch-app/values.yaml
+++ b/charts/incubator/hyperswitch-app/values.yaml
@@ -1914,10 +1914,6 @@ superposition_fallback_cronjob:
   image: ""
   # -- Image pull policy
   imagePullPolicy: IfNotPresent
-  # -- Timeout for the job in seconds
-  activeDeadlineSeconds: 300
-  # -- Number of retries on pod failure
-  backoffLimit: 3
   # -- Restart policy for the job pod
   restartPolicy: OnFailure
   # -- Number of successful job runs to retain in history


### PR DESCRIPTION
Both are optional in Kubernetes:

activeDeadlineSeconds — no default, omitting it means no timeout (job runs until completion or backoffLimit is hit)
backoffLimit — defaults to 6 if omitted

Currently, because of the activeDeadlineSeconds = 300 is causing the following error in the cronjob pod:

 "_Job was active longer than specified deadline_"
