### PR TITLE
fix(analytics): set sqlx as default analytics source

### DIFF
--- a/charts/incubator/hyperswitch-app/Chart.yaml
+++ b/charts/incubator/hyperswitch-app/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: v1.121.0
 description: Hyperswitch is a community-led, open payments switch designed to empower digital businesses by providing fast, reliable, and affordable access to the best payments infrastructure.
 name: hyperswitch-app
 type: application
-version: 1.1.2
+version: 1.1.3
 dependencies:
   - name: redis
     version: 18.6.1

--- a/charts/incubator/hyperswitch-app/values.yaml
+++ b/charts/incubator/hyperswitch-app/values.yaml
@@ -212,7 +212,7 @@ server:
             name: clickhouse
             key: admin-password
       # -- The Analytics source/strategy to be used
-      source: clickhouse
+      source: sqlx
       sqlx:
         # -- Database name
         dbname:


### PR DESCRIPTION
## Summary

Changes the default value of `hyperswitch-app.server.configs.analytics.source` from `clickhouse` to `sqlx`.

## Why

The `clickhouse` analytics path depends on the **Sessionizer service** to consume raw event topics (`hyperswitch-payment-attempt-events`, etc.) and produce sessionized topics that feed the `sessionizer_*` ClickHouse tables. Sessionizer is not part of this chart and is not currently open-source.

As a result, a merchant who runs the chart with default values today sees:

- All Analytics dashboard endpoints returning `500 / HE_00`
- Router logs showing `Code: 60. UNKNOWN_TABLE: 'sessionizer_payment_attempts'` and similar errors
- A broken Analytics tab out of the box, with no obvious fix in the chart

Switching the default to `sqlx` makes the Analytics dashboard work against Postgres directly — no extra services, no schema patches, no closed-source dependency. Merchants who do have Sessionizer + ClickHouse available can still opt in by overriding `analytics.source: clickhouse`.

## Trade-off

`sqlx` doesn't implement the sessionized v2 metric endpoints (e.g. `SessionizedPaymentProcessedAmount`, sankey). Those specific widgets will return 500 instead of populated data. This is a smaller breakage than "entire Analytics tab broken," and merchants who need those features can flip back to `clickhouse` once they have the upstream pipeline in place.

## Changes

- `charts/incubator/hyperswitch-app/values.yaml`: `analytics.source: clickhouse` → `analytics.source: sqlx`
