### PR TITLE
feat(hyperswitch-ucs): add ServiceMonitor support for Victoria Metrics scraping

### DIFF
--- a/charts/incubator/hyperswitch-ucs/Chart.yaml
+++ b/charts/incubator/hyperswitch-ucs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyperswitch-ucs
 description: A Helm chart for Hyperswitch UCS Service
 type: application
-version: 0.1.5
+version: 0.1.6
 AppVersion: "0.1.0"
 keywords:
   - ucs

--- a/charts/incubator/hyperswitch-ucs/README.md
+++ b/charts/incubator/hyperswitch-ucs/README.md
@@ -1,6 +1,6 @@
 # hyperswitch-ucs
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Hyperswitch UCS Service
 
@@ -108,6 +108,18 @@ The following table lists the configurable parameters of the hyperswitch-ucs cha
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor | object | `{"enabled":false,"interval":"","labels":{},"metricRelabelings":[],"namespace":"","path":"/metrics","portName":"metrics","relabelings":[],"scheme":"http","scrapeTimeout":"","targetLabels":[]}` | ServiceMonitor configuration for Victoria Metrics / Prometheus scraping |
+| serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor resource |
+| serviceMonitor.interval | string | `""` | Scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional labels for the ServiceMonitor |
+| serviceMonitor.metricRelabelings | list | `[]` | Metric relabeling rules |
+| serviceMonitor.namespace | string | `""` | Namespace to deploy ServiceMonitor (defaults to release namespace) |
+| serviceMonitor.path | string | `"/metrics"` | Metrics path |
+| serviceMonitor.portName | string | `"metrics"` | Port name to scrape (must match service port name) |
+| serviceMonitor.relabelings | list | `[]` | Relabeling rules |
+| serviceMonitor.scheme | string | `"http"` | HTTP scheme |
+| serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout |
+| serviceMonitor.targetLabels | list | `[]` | Target labels |
 | tolerations | list | `[]` | Tolerations for pod assignment |
 
 ### Connector Service Configurations

--- a/charts/incubator/hyperswitch-ucs/templates/servicemonitor.yaml
+++ b/charts/incubator/hyperswitch-ucs/templates/servicemonitor.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "hyperswitch-ucs.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ tpl .Values.serviceMonitor.namespace . }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "hyperswitch-ucs.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - port: {{ .Values.serviceMonitor.portName | default "metrics" }}
+    {{- with .Values.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    path: {{ .Values.serviceMonitor.path | default "/metrics" }}
+    scheme: {{ .Values.serviceMonitor.scheme | default "http" }}
+    honorLabels: true
+    {{- with .Values.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "hyperswitch-ucs.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- with .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/incubator/hyperswitch-ucs/values.yaml
+++ b/charts/incubator/hyperswitch-ucs/values.yaml
@@ -95,6 +95,43 @@ service:
     # @section -- Connector Service
     targetPort: 8080
 
+# -- ServiceMonitor configuration for Victoria Metrics / Prometheus scraping
+# @section -- Connector Service
+serviceMonitor:
+  # -- Enable ServiceMonitor resource
+  # @section -- Connector Service
+  enabled: false
+  # -- Namespace to deploy ServiceMonitor (defaults to release namespace)
+  # @section -- Connector Service
+  namespace: ""
+  # -- Additional labels for the ServiceMonitor
+  # @section -- Connector Service
+  labels: {}
+  # -- Port name to scrape (must match service port name)
+  # @section -- Connector Service
+  portName: "metrics"
+  # -- Metrics path
+  # @section -- Connector Service
+  path: "/metrics"
+  # -- Scrape interval
+  # @section -- Connector Service
+  interval: ""
+  # -- Scrape timeout
+  # @section -- Connector Service
+  scrapeTimeout: ""
+  # -- HTTP scheme
+  # @section -- Connector Service
+  scheme: "http"
+  # -- Relabeling rules
+  # @section -- Connector Service
+  relabelings: []
+  # -- Metric relabeling rules
+  # @section -- Connector Service
+  metricRelabelings: []
+  # -- Target labels
+  # @section -- Connector Service
+  targetLabels: []
+
 # -- Ingress configuration
 # @section -- Connector Service
 ingress:


### PR DESCRIPTION
## Summary

- Adds `ServiceMonitor` template to `hyperswitch-ucs` helm chart, enabling Victoria Metrics / Prometheus to scrape UCS metrics
- Adds `serviceMonitor` defaults block to `values.yaml` (disabled by default, opt-in per environment)
- UCS already exposes a metrics endpoint on port `8080` at `/metrics` — this PR wires up the ServiceMonitor to point at it
- Pattern mirrors the existing `hyperswitch-encryption-service` ServiceMonitor implementation

## Why

Victoria Metrics was not scraping UCS metrics because no `ServiceMonitor` resource was being created. The service port `metrics: 8080` already existed in the chart but had no corresponding monitor.

## Test plan

- [ ] Enable via `serviceMonitor.enabled: true` in sandbox/integ infra values (separate PR in hyperswitch-infra)
- [ ] Verify ServiceMonitor resource is created in `hyperswitch-ucs-sandbox` namespace
- [ ] Verify Victoria Metrics scrapes UCS metrics successfully in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)