### PR TITLE
feat(superposition): added superposition cron job inside container

### DIFF
--- a/charts/incubator/hyperswitch-app/README.md
+++ b/charts/incubator/hyperswitch-app/README.md
@@ -2144,23 +2144,15 @@ Refer our [postman collection](https://www.postman.com/hyperswitch/workspace/hyp
     <td><div><code>false</code></div></td>
     <td>Enable the CronJob that syncs superposition config to EFS</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1922">superposition_fallback_cronjob.failedJobsHistoryLimit</a></div></td>
+    <td><div><a href="./values.yaml#L1918">superposition_fallback_cronjob.failedJobsHistoryLimit</a></div></td>
     <td><div><code>1</code></div></td>
     <td>Number of failed job runs to retain in history</td>
-  </tr><tr>
-    <td><div><a href="./values.yaml#L1914">superposition_fallback_cronjob.image</a></div></td>
-    <td><div><code>""</code></div></td>
-    <td>Container image for the backup job</td>
-  </tr><tr>
-    <td><div><a href="./values.yaml#L1916">superposition_fallback_cronjob.imagePullPolicy</a></div></td>
-    <td><div><code>"IfNotPresent"</code></div></td>
-    <td>Image pull policy</td>
   </tr><tr>
     <td><div><a href="./values.yaml#L1910">superposition_fallback_cronjob.name</a></div></td>
     <td><div><code>"superposition-config-backup-cronjob"</code></div></td>
     <td>Name of the CronJob resource</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1940">superposition_fallback_cronjob.resources</a></div></td>
+    <td><div><a href="./values.yaml#L1936">superposition_fallback_cronjob.resources</a></div></td>
     <td><div><code>{
   "limits": {
     "cpu": "100m",
@@ -2173,11 +2165,11 @@ Refer our [postman collection](https://www.postman.com/hyperswitch/workspace/hyp
 }</code></div></td>
     <td>Resource requests and limits for the cronjob container</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1918">superposition_fallback_cronjob.restartPolicy</a></div></td>
+    <td><div><a href="./values.yaml#L1914">superposition_fallback_cronjob.restartPolicy</a></div></td>
     <td><div><code>"OnFailure"</code></div></td>
     <td>Restart policy for the job pod</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1924">superposition_fallback_cronjob.retentionCount</a></div></td>
+    <td><div><a href="./values.yaml#L1920">superposition_fallback_cronjob.retentionCount</a></div></td>
     <td><div><code>"10"</code></div></td>
     <td>Number of backup files to retain in EFS</td>
   </tr><tr>
@@ -2185,11 +2177,11 @@ Refer our [postman collection](https://www.postman.com/hyperswitch/workspace/hyp
     <td><div><code>"* * * * *"</code></div></td>
     <td>Cron schedule (minimum Kubernetes CronJob interval is 1 minute)</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1920">superposition_fallback_cronjob.successfulJobsHistoryLimit</a></div></td>
+    <td><div><a href="./values.yaml#L1916">superposition_fallback_cronjob.successfulJobsHistoryLimit</a></div></td>
     <td><div><code>3</code></div></td>
     <td>Number of successful job runs to retain in history</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1926">superposition_fallback_cronjob.superposition</a></div></td>
+    <td><div><a href="./values.yaml#L1922">superposition_fallback_cronjob.superposition</a></div></td>
     <td><div><code>{
   "endpoint": "http://localhost:8081",
   "orgId": "",
@@ -2199,23 +2191,23 @@ Refer our [postman collection](https://www.postman.com/hyperswitch/workspace/hyp
 }</code></div></td>
     <td>Superposition service connection details</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1928">superposition_fallback_cronjob.superposition.endpoint</a></div></td>
+    <td><div><a href="./values.yaml#L1924">superposition_fallback_cronjob.superposition.endpoint</a></div></td>
     <td><div><code>"http://localhost:8081"</code></div></td>
     <td>Superposition API endpoint URL</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1936">superposition_fallback_cronjob.superposition.orgId</a></div></td>
+    <td><div><a href="./values.yaml#L1932">superposition_fallback_cronjob.superposition.orgId</a></div></td>
     <td><div><code>""</code></div></td>
     <td>Superposition organisation ID (must match superposition.org_id)</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1934">superposition_fallback_cronjob.superposition.tokenSecretKey</a></div></td>
+    <td><div><a href="./values.yaml#L1930">superposition_fallback_cronjob.superposition.tokenSecretKey</a></div></td>
     <td><div><code>"ROUTER__SUPERPOSITION__TOKEN"</code></div></td>
     <td>Key within the secret that holds the token value</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1932">superposition_fallback_cronjob.superposition.tokenSecretName</a></div></td>
+    <td><div><a href="./values.yaml#L1928">superposition_fallback_cronjob.superposition.tokenSecretName</a></div></td>
     <td><div><code>"hyperswitch-secrets"</code></div></td>
     <td>Name of the Kubernetes Secret containing the Superposition API token.   tokenSecretName: "hyperswitch-secrets"   tokenSecretKey: "ROUTER__SUPERPOSITION__TOKEN"</td>
   </tr><tr>
-    <td><div><a href="./values.yaml#L1938">superposition_fallback_cronjob.superposition.workspaceId</a></div></td>
+    <td><div><a href="./values.yaml#L1934">superposition_fallback_cronjob.superposition.workspaceId</a></div></td>
     <td><div><code>""</code></div></td>
     <td>Superposition workspace ID (must match superposition.workspace_id)</td>
   </tr><tr>

--- a/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
+++ b/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
@@ -30,8 +30,163 @@ spec:
             fsGroup: 1000
           containers:
             - name: superposition-config-backup-cronjob
-              image: {{ .Values.superposition_fallback_cronjob.image | default "" }}
+              image: {{ .Values.superposition_fallback_cronjob.image | default "python:3.13-alpine" }}
               imagePullPolicy: {{ .Values.superposition_fallback_cronjob.imagePullPolicy | default "IfNotPresent" }}
+              command:
+                - python3
+                - -c
+              args:
+                - |
+                  import json
+                  import os
+                  import time
+                  import urllib.error
+                  import urllib.request
+                  from pathlib import Path
+
+
+                  def log(message):
+                      print(message, flush=True)
+
+
+                  required_variables = (
+                      "SUPERPOSITION_ENDPOINT",
+                      "SUPERPOSITION_TOKEN",
+                      "SUPERPOSITION_ORG_ID",
+                      "SUPERPOSITION_WORKSPACE_ID",
+                      "EFS_MOUNT_PATH",
+                  )
+                  missing_variables = [
+                      name for name in required_variables if not os.environ.get(name)
+                  ]
+                  if missing_variables:
+                      raise RuntimeError(
+                          "Missing required environment variables: "
+                          + ", ".join(missing_variables)
+                      )
+
+                  endpoint = os.environ["SUPERPOSITION_ENDPOINT"].rstrip("/")
+                  token = os.environ["SUPERPOSITION_TOKEN"]
+                  org_id = os.environ["SUPERPOSITION_ORG_ID"]
+                  workspace_id = os.environ["SUPERPOSITION_WORKSPACE_ID"]
+                  mount_path = Path(os.environ["EFS_MOUNT_PATH"])
+                  retention = int(os.environ.get("RETENTION_COUNT", "10"))
+
+                  if retention < 0:
+                      raise ValueError("RETENTION_COUNT must be zero or greater")
+                  if not mount_path.exists():
+                      raise RuntimeError(f"Mount path does not exist: {mount_path}")
+                  if not mount_path.is_dir():
+                      raise RuntimeError(f"Mount path is not a directory: {mount_path}")
+
+                  started_at = time.monotonic()
+                  config_url = f"{endpoint}/config/json"
+                  log(
+                      "Starting Superposition config backup for "
+                      f"workspace {workspace_id} in org {org_id}"
+                  )
+                  log(f"Fetching configuration from {config_url}")
+
+                  request = urllib.request.Request(
+                      config_url,
+                      data=b"",
+                      method="POST",
+                      headers={
+                          "Authorization": f"Bearer {token}",
+                          "x-org-id": org_id,
+                          "x-workspace": workspace_id,
+                      },
+                  )
+
+                  response_body = None
+                  for attempt in range(1, 4):
+                      try:
+                          with urllib.request.urlopen(request, timeout=30) as response:
+                              response_body = response.read().decode("utf-8")
+                          break
+                      except urllib.error.HTTPError as error:
+                          details = error.read(4096).decode("utf-8", errors="replace")
+                          if (error.code == 429 or error.code >= 500) and attempt < 3:
+                              log(
+                                  f"Request failed with HTTP {error.code}; "
+                                  f"retrying ({attempt}/3)"
+                              )
+                              time.sleep(2 ** (attempt - 1))
+                              continue
+                          raise RuntimeError(
+                              f"Failed to fetch config: HTTP {error.code}: {details}"
+                          ) from error
+                      except urllib.error.URLError as error:
+                          if attempt < 3:
+                              log(f"Request failed; retrying ({attempt}/3): {error.reason}")
+                              time.sleep(2 ** (attempt - 1))
+                              continue
+                          raise RuntimeError(
+                              f"Failed to fetch config: {error.reason}"
+                          ) from error
+
+                  if response_body is None:
+                      raise RuntimeError("Failed to fetch config: empty response")
+
+                  json_content = response_body.replace("\r\n", "\n").replace("\r", "")
+                  log(f"Fetched JSON config ({len(json_content.encode('utf-8'))} bytes)")
+
+                  timestamp = int(time.time())
+                  versioned_filename = f"config-{timestamp}.json"
+                  versioned_file = mount_path / versioned_filename
+                  versioned_temp = mount_path / f".tmp-{versioned_filename}"
+                  latest_file = mount_path / "backup-LATEST.json"
+                  latest_temp = mount_path / ".tmp-backup-LATEST.json"
+
+                  versioned_temp.write_text(json_content, encoding="utf-8")
+                  os.replace(versioned_temp, versioned_file)
+                  log(f"Saved versioned config: {versioned_file}")
+
+                  latest_temp.write_text(json_content, encoding="utf-8")
+                  os.replace(latest_temp, latest_file)
+                  log(f"Created constant filename: {latest_file}")
+
+                  symlink_path = mount_path / "current"
+                  symlink_temp = mount_path / ".tmp-current"
+                  try:
+                      symlink_temp.unlink()
+                  except FileNotFoundError:
+                      pass
+                  symlink_temp.symlink_to(versioned_filename)
+                  os.replace(symlink_temp, symlink_path)
+                  log(f"Updated symlink: {symlink_path} -> {versioned_filename}")
+
+                  config_files = sorted(
+                      path
+                      for path in mount_path.iterdir()
+                      if path.name.startswith("config-")
+                      and path.name.endswith(".json")
+                  )
+                  files_to_delete = max(0, len(config_files) - retention)
+                  log(
+                      f"Found {len(config_files)} versions; "
+                      f"deleting {files_to_delete} old versions"
+                  )
+                  for old_file in config_files[:files_to_delete]:
+                      old_file.unlink()
+                      log(f"Deleted old version: {old_file}")
+
+                  with latest_file.open(encoding="utf-8") as backup_file:
+                      parsed_config = json.load(backup_file)
+                  if not isinstance(parsed_config, dict):
+                      raise RuntimeError("Backup file is not a JSON object")
+                  if not (
+                      "default-configs" in parsed_config
+                      or "default_configs" in parsed_config
+                  ):
+                      log("Warning: backup file missing default-configs/default_configs key")
+                  if "overrides" not in parsed_config:
+                      log("Warning: backup file missing overrides key")
+
+                  log(
+                      f"Backup completed successfully in "
+                      f"{time.monotonic() - started_at:.3f}s - {versioned_filename}"
+                  )
               env:
                 - name: SUPERPOSITION_ENDPOINT
                   value: {{ .Values.superposition_fallback_cronjob.superposition.endpoint | default "http://localhost:8081" | quote }}

--- a/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
+++ b/charts/incubator/hyperswitch-app/templates/misc/cronjob.yaml
@@ -30,8 +30,7 @@ spec:
             fsGroup: 1000
           containers:
             - name: superposition-config-backup-cronjob
-              image: {{ .Values.superposition_fallback_cronjob.image | default "python:3.13-alpine" }}
-              imagePullPolicy: {{ .Values.superposition_fallback_cronjob.imagePullPolicy | default "IfNotPresent" }}
+              image: python:3.13-alpine
               command:
                 - python3
                 - -c

--- a/charts/incubator/hyperswitch-app/values.yaml
+++ b/charts/incubator/hyperswitch-app/values.yaml
@@ -1910,10 +1910,6 @@ superposition_fallback_cronjob:
   name: "superposition-config-backup-cronjob"
   # -- Cron schedule (minimum Kubernetes CronJob interval is 1 minute)
   schedule: "* * * * *"
-  # -- Container image for the backup job
-  image: ""
-  # -- Image pull policy
-  imagePullPolicy: IfNotPresent
   # -- Restart policy for the job pod
   restartPolicy: OnFailure
   # -- Number of successful job runs to retain in history


### PR DESCRIPTION
Previously, the CronJob depended on a separate snapshot service/container implementation to call Superposition and prepare the backup. The CronJob was only responsible for scheduling that external component.

Now, the CronJob performs the Superposition API call and snapshot workflow directly.

Benefits:

- Removes the dependency on a separately built and deployed snapshot service.
- Eliminates the Rust binary’s continuous polling loop; Kubernetes controls execution through the Cron schedule.
- Reduces deployment and release coordination—no separate service image/version needs to be maintained.
- Gives each scheduled run a clear success or failure status in Kubernetes.
- Uses Kubernetes-native retries, concurrency control, logs, and job history.
- Reads credentials directly from Kubernetes Secrets.
- Writes directly to the mounted EFS/PVC, reducing intermediate components and failure points.
- Makes the workflow self-contained in the Helm deployment.
- Resources are consumed only while a backup Job is running instead of by a continuously running service.

In short: we changed from “CronJob waits for or launches a separately maintained backup implementation” to “CronJob directly fetches, validates, versions, and stores the Superposition configuration.” This simplifies the architecture and improves operational visibility.

The trade-off is that the backup logic now lives as embedded Python in the Helm template, so changes to that logic require a Helm chart release.