### PR TITLE
feat(hyperswitch-app): add multi-AZ scheduling and PDB for router

### DIFF
--- a/charts/incubator/hyperswitch-app/README.md
+++ b/charts/incubator/hyperswitch-app/README.md
@@ -416,6 +416,43 @@ Refer our [postman collection](https://www.postman.com/hyperswitch/workspace/hyp
     <td>Istio configuration</td>
   </tr></tbody>
 </table>
+<h3>Multi-AZ</h3>
+<table height="400px">
+<thead>
+	<th >Key</th>
+	<th >Default</th>
+	<th >Description</th>
+</thead>
+<tbody><tr>
+    <td><div><a href="./values.yaml#L93">multiAz.enabled</a></div></td>
+    <td><div><code>false</code></div></td>
+    <td>Enable multi-AZ scheduling (topology spread constraints and PDBs)</td>
+  </tr><tr>
+    <td><div><a href="./values.yaml#L97">multiAz.topologyKey</a></div></td>
+    <td><div><code>"topology.kubernetes.io/zone"</code></div></td>
+    <td>Topology key used to spread pods across failure domains</td>
+  </tr><tr>
+    <td><div><a href="./values.yaml#L99">multiAz.maxSkew</a></div></td>
+    <td><div><code>1</code></div></td>
+    <td>Maximum difference in number of pods between zones</td>
+  </tr><tr>
+    <td><div><a href="./values.yaml#L102">multiAz.whenUnsatisfiable</a></div></td>
+    <td><div><code>"DoNotSchedule"</code></div></td>
+    <td>Scheduling policy when the spread constraint cannot be satisfied. Allowed values: DoNotSchedule | ScheduleAnyway</td>
+  </tr><tr>
+    <td><div><a href="./values.yaml#L106">multiAz.podDisruptionBudget.enabled</a></div></td>
+    <td><div><code>true</code></div></td>
+    <td>Create PDBs for the app components</td>
+  </tr><tr>
+    <td><div><a href="./values.yaml#L108">multiAz.podDisruptionBudget.minAvailable</a></div></td>
+    <td><div><code>"50%"</code></div></td>
+    <td>Minimum available pods (mutually exclusive with maxUnavailable)</td>
+  </tr><tr>
+    <td><div><a href="./values.yaml#L110">multiAz.podDisruptionBudget.maxUnavailable</a></div></td>
+    <td><div><code>""</code></div></td>
+    <td>Maximum unavailable pods (mutually exclusive with minAvailable)</td>
+  </tr></tbody>
+</table>
 <h3>App Server Secrets</h3>
 <table height="400px">
 <thead>

--- a/charts/incubator/hyperswitch-app/templates/NOTES.txt
+++ b/charts/incubator/hyperswitch-app/templates/NOTES.txt
@@ -1,3 +1,17 @@
+{{- if .Values.multiAz.enabled }}
+
+*******************************************************************************
+NOTICE: multi-AZ scheduling is enabled for the router.
+
+- Worker nodes MUST be labelled with "{{ .Values.multiAz.topologyKey }}".
+- Router replicas (or autoscaling minReplicas) should be at least the number of
+  availability zones, otherwise pods may remain Pending because
+  "whenUnsatisfiable: {{ .Values.multiAz.whenUnsatisfiable }}" is set.
+- Consider using external managed PostgreSQL/Redis/Kafka/ClickHouse for full
+  data-plane high availability.
+*******************************************************************************
+
+{{- end }}
 1. Get the Application URL:
    - If Ingress is not available, use port-forwarding:
      ```shell

--- a/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
@@ -120,6 +120,16 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and .Values.multiAz.enabled .Values.services.router.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.multiAz.maxSkew }}
+          topologyKey: {{ .Values.multiAz.topologyKey }}
+          whenUnsatisfiable: {{ .Values.multiAz.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app: {{ include "hyperswitch-server.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- end }}
       {{- with (default .Values.global.nodeSelector .Values.server.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/incubator/hyperswitch-app/templates/router/pdb.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/pdb.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.multiAz.enabled .Values.multiAz.podDisruptionBudget.enabled .Values.services.router.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "hyperswitch-server.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hyperswitch.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "hyperswitch-server.name" . }}
+    app: {{ include "hyperswitch-server.name" . }}
+spec:
+  {{- if .Values.multiAz.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.multiAz.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.multiAz.podDisruptionBudget.minAvailable | default "50%" }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ include "hyperswitch-server.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/incubator/hyperswitch-app/values.yaml
+++ b/charts/incubator/hyperswitch-app/values.yaml
@@ -87,6 +87,27 @@ global:
     managedBy: hyperswitch
   # -- Environmant variables that are to be used by the hyperswitch application services
   env: []
+# Multi-AZ scheduling configuration for the Hyperswitch app workloads.
+# Currently applied to the router only.
+# @section -- Multi-AZ
+multiAz:
+  # -- Enable multi-AZ scheduling (topology spread constraints and PDBs)
+  enabled: false
+  # -- Topology key used to spread pods across failure domains
+  topologyKey: topology.kubernetes.io/zone
+  # -- Maximum difference in number of pods between zones
+  maxSkew: 1
+  # -- Scheduling policy when the spread constraint cannot be satisfied.
+  # Allowed values: DoNotSchedule | ScheduleAnyway
+  whenUnsatisfiable: DoNotSchedule
+  # PodDisruptionBudget configuration
+  podDisruptionBudget:
+    # -- Create PDBs for the app components
+    enabled: true
+    # -- Minimum available pods (mutually exclusive with maxUnavailable)
+    minAvailable: "50%"
+    # -- Maximum unavailable pods (mutually exclusive with minAvailable)
+    maxUnavailable: ""
 # -- Common references for templated resource names
 _references:
   # -- Hyperswitch secrets reference with release name prefix


### PR DESCRIPTION
Adds an opt-in multiAz values block that spreads router pods across availability zones via topologySpreadConstraints and creates a PodDisruptionBudget to maintain availability during voluntary disruptions. Disabled by default to keep dev/single-zone installs unchanged.