### PR TITLE
fix(analysistemplate): split shared interval default from prometheus provider default

### DIFF
--- a/charts/incubator/hyperswitch-app/templates/_helpers.tpl
+++ b/charts/incubator/hyperswitch-app/templates/_helpers.tpl
@@ -600,3 +600,13 @@ log.telemetry.otel_exporter_otlp_endpoint: "opentelemetry-collector.url"
 {{- fail "argoRollouts.canary.analysis.metrics must have at least one metric when analysis is enabled" }}
 {{- end }}
 {{- end -}}
+
+{{- /* Merge one metric with the chart's shared defaults. Scalar interval applies to all metrics. Prometheus provider defaults apply only to prometheus metrics. */ -}}
+{{- define "hyperswitch.mergeAnalysisMetric" -}}
+{{- $shared := dict "interval" .sharedInterval -}}
+{{- $metric := mergeOverwrite (deepCopy $shared) .metric -}}
+{{- if or (not (hasKey .metric "provider")) (hasKey .metric.provider "prometheus") -}}
+{{- $metric = mergeOverwrite $metric (dict "provider" (dict "prometheus" (dict "address" .prometheusAddress "timeout" .prometheusTimeout))) -}}
+{{- end -}}
+{{- toYaml $metric -}}
+{{- end -}}

--- a/charts/incubator/hyperswitch-app/templates/router/analysistemplate.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/analysistemplate.yaml
@@ -2,10 +2,10 @@
 {{- $analysis := .Values.argoRollouts.canary.analysis }}
 {{- include "hyperswitch.validateAnalysisConfig" . }}
 {{- $addr := $analysis.victoriaMetrics.address | required "argoRollouts.canary.analysis.victoriaMetrics.address is required when analysis is enabled" }}
-{{- $defaults := dict "interval" $analysis.interval "provider" (dict "prometheus" (dict "address" $addr "timeout" $analysis.timeout)) }}
 {{- $mergedMetrics := list }}
 {{- range $analysis.metrics }}
-{{- $mergedMetrics = append $mergedMetrics (mergeOverwrite (deepCopy $defaults) .) }}
+{{- $merged := include "hyperswitch.mergeAnalysisMetric" (dict "metric" . "sharedInterval" $analysis.interval "prometheusAddress" $addr "prometheusTimeout" $analysis.timeout) | fromYaml }}
+{{- $mergedMetrics = append $mergedMetrics $merged }}
 {{- end }}
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate

--- a/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
@@ -61,6 +61,9 @@ spec:
         - name: stable-hash
           valueFrom:
             podTemplateHashValue: Stable
+        {{- with .Values.argoRollouts.canary.analysis.args }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.argoRollouts.canary.antiAffinity}}
       antiAffinity:


### PR DESCRIPTION
This pull request introduces improvements to how analysis metrics are merged and managed in the Helm chart, and adds support for injecting custom analysis arguments into the deployment. The main changes focus on making the merging of analysis metric defaults more modular and flexible, and enhancing configuration options for Argo Rollouts.

### Analysis metrics merging improvements

* Added the `hyperswitch.mergeAnalysisMetric` template in `_helpers.tpl` to handle merging shared metric defaults and provider-specific defaults in a more reusable and maintainable way. This ensures that scalar intervals and Prometheus provider defaults are correctly applied to each metric.
* Updated `analysistemplate.yaml` to use the new `hyperswitch.mergeAnalysisMetric` template when merging analysis metrics, replacing the previous inline logic for improved clarity and maintainability.

### Deployment configuration enhancements

* Modified `deployment.yaml` to support injecting custom analysis arguments into the deployment spec when provided via `.Values.argoRollouts.canary.analysis.args`, increasing configuration flexibility for analysis jobs.