### PR TITLE
fix(rollout): skip secretKeyRef args in rollout analysis.args passthrough

### DIFF
--- a/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
@@ -61,8 +61,10 @@ spec:
         - name: stable-hash
           valueFrom:
             podTemplateHashValue: Stable
-        {{- with .Values.argoRollouts.canary.analysis.args }}
-        {{- toYaml . | nindent 8 }}
+        {{- range .Values.argoRollouts.canary.analysis.args }}
+        {{- if not (and .valueFrom .valueFrom.secretKeyRef) }}
+        - {{ toYaml . | nindent 10 | trim }}
+        {{- end }}
         {{- end }}
       {{- end }}
       {{- with .Values.argoRollouts.canary.antiAffinity}}


### PR DESCRIPTION

### Description

**Problem.** Argo Rollouts' CRD defines two different `args[].valueFrom` shapes:
- `AnalysisTemplate`/`AnalysisRun`: supports `secretKeyRef`, `fieldRef`, plus others.
- `Rollout.spec.strategy.canary.analysis.args[]`: supports **only** `podTemplateHashValue` and `fieldRef` — **no** `secretKeyRef`.

The unconditional passthrough added previously rendered any `valueFrom` from values (including `secretKeyRef`) onto the Rollout spec, causing ArgoCD server-side-apply to fail with:
```text
Failed to compare desired state to live state: failed to calculate diff: error calculating structured merge diff: error building typed value from config resource: .spec.strategy.canary.analysis.args[2].valueFrom.secretKeyRef: field not declared in schema
```

**Fix.** Filter Rollout-side passthrough to exclude any arg declaring `valueFrom.secretKeyRef`. The AnalysisTemplate (in `analysistemplate.yaml`) already renders the full args list including `secretKeyRef` — that's where Argo resolves the secret at AnalysisRun time. The Rollout doesn't need to carry it.

**Files changed:**
- `templates/router/deployment.yaml` — replace unconditional `{{ with … }}…{{ toYaml … }}…{{ end }}` with a `{{ range … }}{{ if not (and .valueFrom .valueFrom.secretKeyRef) }}…{{ end }}{{ end }}` filter.

**Backward compatible:**
- Values with no `args` → no change.
- Values with args without `valueFrom` (like the standard `canary-hash`/`stable-hash` pod-template-hash args) → unchanged (rolled out under their original entries already).
- Values with args using `value` or `valueFrom.fieldRef`/`valueFrom.podTemplateHashValue` → still passed through to the Rollout.
- Values with args using `valueFrom.secretKeyRef` → AnalysisTemplate carries them; **Rollout skips them**. Behaviour equivalent to before, but no longer schema-violating.

**Verified with helm template:**

Rollout `args` (no `secretKeyRef`):
```yaml
args:
- name: canary-hash
  valueFrom:
    podTemplateHashValue: Latest
- name: stable-hash
  valueFrom:
    podTemplateHashValue: Stable
- name: other-static
  value: hello
- name: env-from-field
  valueFrom:
    fieldRef:
      fieldPath: metadata.name
```



