### PR TITLE
feat(hyperswitch-app): propagate raw image tag through infra values for router

### DIFF
--- a/charts/incubator/hyperswitch-app/templates/_envs.tpl
+++ b/charts/incubator/hyperswitch-app/templates/_envs.tpl
@@ -50,3 +50,8 @@
     fieldRef:
       fieldPath: metadata.labels['version']
 {{- end -}}
+
+{{- define "router.infra.values.envs" -}}
+- name: IMAGE_VERSION_VALUE
+  value: {{ .Values.services.router.version | toString | quote }}
+{{- end -}}

--- a/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
@@ -115,6 +115,7 @@ spec:
       labels:
         app: {{ include "hyperswitch-server.name" . }}
         version: {{ include "version.suffix" (.Values.services.router.version | toString) | quote }}
+        image-version: {{ .Values.services.router.version | toString | quote }}
         {{- include "hyperswitch.labels" . | nindent 8 }}
         {{- with (.Values.server.labels | default .Values.global.labels) }}
         {{- toYaml . | nindent 8 }}
@@ -161,6 +162,7 @@ spec:
           {{- with .Values.server.env }}
           {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- include "router.infra.values.envs" . | nindent 12 }}
           {{- include "metadata.envs" . | nindent 12 }}
           {{- include "generic.envs" . | nindent 12 }}
           {{- include "postgresql.secrets.envs" . | nindent 12 }}

--- a/charts/incubator/hyperswitch-app/values.yaml
+++ b/charts/incubator/hyperswitch-app/values.yaml
@@ -189,6 +189,8 @@ server:
   #       name: <name_of_configmap_or_secret>
   #       key: <key_in_configmap_or_secret>
   configs:
+    infra_values:
+      version: IMAGE_VERSION_VALUE
     chat:
       # Enable or disable chat features
       enabled: false


### PR DESCRIPTION
## Summary

Propagate the raw router image tag into `infra_values.version`.
## Changes

- Add `image-version` pod-template label using the raw router image tag.
- Add `IMAGE_VERSION_VALUE` to the Router container from `services.router.version`.
- Add `ROUTER__INFRA_VALUES__VERSION=IMAGE_VERSION_VALUE` to the Router ConfigMap.
- Preserve the existing sanitized `version` label and `VERSION_VALUE` behavior.

## Resulting Router Environment

```text
IMAGE_VERSION_VALUE=2026.08.06.0-fred
ROUTER__INFRA_VALUES__VERSION=IMAGE_VERSION_VALUE
```