### PR TITLE
fix(rollout): make analysis args fully dynamic with structural filtering

### DIFF
--- a/charts/incubator/hyperswitch-app/templates/router/analysistemplate.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/analysistemplate.yaml
@@ -17,7 +17,13 @@ metadata:
 spec:
   {{- if $analysis.args }}
   args:
-{{ toYaml $analysis.args | nindent 4 }}
+  {{- range $analysis.args }}
+  {{- if and .valueFrom .valueFrom.secretKeyRef }}
+  - {{ toYaml . | nindent 4 | trim }}
+  {{- else }}
+  - name: {{ .name }}
+  {{- end }}
+  {{- end }}
   {{- end }}
   {{- if not $analysis.enforce }}
   dryRun:

--- a/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
@@ -55,12 +55,6 @@ spec:
         - templateName: {{ include "hyperswitch-server.name" . }}-canary
         startingStep: {{ .Values.argoRollouts.canary.analysis.startingStep | default 2 }}
         args:
-        - name: canary-hash
-          valueFrom:
-            podTemplateHashValue: Latest
-        - name: stable-hash
-          valueFrom:
-            podTemplateHashValue: Stable
         {{- range .Values.argoRollouts.canary.analysis.args }}
         {{- if not (and .valueFrom .valueFrom.secretKeyRef) }}
         - {{ toYaml . | nindent 10 | trim }}

--- a/charts/incubator/hyperswitch-app/values.yaml
+++ b/charts/incubator/hyperswitch-app/values.yaml
@@ -1407,7 +1407,11 @@ argoRollouts:
       timeout: 30
       args:
         - name: canary-hash
+          valueFrom:
+            podTemplateHashValue: Latest
         - name: stable-hash
+          valueFrom:
+            podTemplateHashValue: Stable
       # -- Metrics list; shared interval/address/timeout auto-injected via mergeOverwrite.
       # Override per-metric (e.g. interval: 60s). Add/remove entries to customize.
       metrics:


### PR DESCRIPTION
## Problem

The Rollout template hardcoded `canary-hash` and `stable-hash` args with
`valueFrom: podTemplateHashValue`, then ranged over `values.yaml` args with
a name-based filter (`ne .name "canary-hash"`) to avoid duplicates. This was
fragile — adding any new `podTemplateHashValue` arg required updating the
template.

Additionally, the AnalysisTemplate rendered ALL args via `toYaml`, which
incorrectly included `valueFrom.fieldRef` and `value` in `spec.args` —
these are Rollout-only concepts that shouldn't be in the AnalysisTemplate.

## Root Cause

Commit `e46f312` (#310) re-introduced a passthrough loop with a filter that
only excluded `secretKeyRef` args. Bare-name args (`canary-hash`,
`stable-hash`) from `values.yaml` passed through the filter, creating
duplicates where the last entry (empty string) overwrote the resolved
pod template hash — causing all canary metrics to resolve `unresolved`.

## Changes

- **`deployment.yaml`**: Removed hardcoded `canary-hash`/`stable-hash`
  blocks. Single `range` loop skips only `secretKeyRef` args (resolved by
  AnalysisTemplate, not passed from Rollout).
- **`analysistemplate.yaml`**: Replaced raw `toYaml` dump with conditional
  rendering — `secretKeyRef` args keep full definition, all others strip
  to bare `name`.
- **`values.yaml`**: Added `valueFrom: podTemplateHashValue: Latest/Stable`
  to default `canary-hash`/`stable-hash` args.

