### PR TITLE
fix(rollout): scope router image-version by release for canary SR isolation

### DIFF
--- a/charts/incubator/hyperswitch-app/templates/_envs.tpl
+++ b/charts/incubator/hyperswitch-app/templates/_envs.tpl
@@ -53,5 +53,5 @@
 
 {{- define "router.infra.values.envs" -}}
 - name: IMAGE_VERSION_VALUE
-  value: {{ .Values.services.router.version | toString | quote }}
+  value: {{ include "router.image.version" . | quote }}
 {{- end -}}

--- a/charts/incubator/hyperswitch-app/templates/_helpers.tpl
+++ b/charts/incubator/hyperswitch-app/templates/_helpers.tpl
@@ -26,6 +26,22 @@ Convert version format from v1.115.0 to v1o115o0 for Kubernetes labels
 {{- . | replace "." "o" -}}
 {{- end -}}
 
+{{/*
+Release-scoped router image version, e.g. `integ_2026.08.12.0-fred`.
+
+Used for BOTH the `image-version` pod label and the IMAGE_VERSION_VALUE env var the
+router emits as the analytics `version` field. Canary analysis reads the label and
+matches it against that column, so the two must never drift.
+
+The release segment scopes canary SR to one rollout: several releases share a Kafka
+topic and the AB tables, so without it other releases land in the "stable" bucket.
+`_` is used because release names are prefixes of each other (`integ` vs
+`integ-custom`), so a `-` separator could not be split unambiguously.
+*/}}
+{{- define "router.image.version" -}}
+{{- printf "%s_%s" .Release.Name (.Values.services.router.version | toString) -}}
+{{- end -}}
+
 # Define `hyperswitch-server.name` template
 {{- define "hyperswitch-server.name" -}}
 {{- printf "%s-hyperswitch-server" .Release.Name | trunc 63 | trimSuffix "-" -}}

--- a/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
+++ b/charts/incubator/hyperswitch-app/templates/router/deployment.yaml
@@ -109,7 +109,7 @@ spec:
       labels:
         app: {{ include "hyperswitch-server.name" . }}
         version: {{ include "version.suffix" (.Values.services.router.version | toString) | quote }}
-        image-version: {{ .Values.services.router.version | toString | quote }}
+        image-version: {{ include "router.image.version" . | quote }}
         {{- include "hyperswitch.labels" . | nindent 8 }}
         {{- with (.Values.server.labels | default .Values.global.labels) }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Problem

Canary SR analysis splits canary from stable using the analytics `version` column,
which the router emits from its image tag. The tag alone is not unique across
releases: `integ`, `integ-custom`, `integ-custom-pm` and `dev` all publish to the
same Kafka topic and land in the same AB tables.

The stable-side predicate is `version IS NOT NULL AND version != <canary>`, so
every other release's traffic is counted as "stable". On representative data the
stable bucket reads **16.67% SR over 6 rows** when the real figure is **50% over
2 rows** — enough to abort a healthy canary once these metrics become gating.

## Change

Add a `router.image.version` helper emitting `<release>_<tag>`
(e.g. `integ_2026.08.12.0-fred`), used for both the `image-version` pod label and
the `IMAGE_VERSION_VALUE` env var. Consumers can then recover the release with
`splitByChar('_', version)[1]` and scope SR to a single rollout.

`_` is the separator because release names are prefixes of one another — `integ`
vs `integ-custom` — so a `-` separator could not be split unambiguously, and a
`LIKE 'integ-%'` prefix match would readmit `integ-custom-...` rows.

Both call sites go through the one helper: the Rollout resolves `canary-version`
from the label and matches it against the `version` column, so if the label and
the env var ever diverged the SR gate would silently match zero rows.

## Scope

Router only. No change to consumer/producer/drainer, the `version`/`app`/
`app.kubernetes.io/*` labels, the ConfigMap, or the
`ROUTER__INFRA_VALUES__VERSION` → `IMAGE_VERSION_VALUE` indirection the app
depends on.

